### PR TITLE
Import remaining support functions

### DIFF
--- a/src/maths.ts
+++ b/src/maths.ts
@@ -27,3 +27,41 @@ export function modr(x: number, y: number) {
 export function intdivr(x: number, y: number) {
     return Math.floor(x / y);
 }
+
+export function odinSum1(x: number[], from: number, to: number) {
+    let tot = 0.0;
+    for (let i = from; i < to; ++i) {
+        tot += x[i];
+    }
+    return tot;
+}
+
+// These are generated and are a bit fiddly to get right. I've copied
+// over the first 3 as they're generally enough for the tests and for
+// most models that anyone will actually write!
+export function odinSum2(x: number[], iFrom: number, iTo: number, jFrom: number, jTo: number, dim1: number) {
+    let tot = 0.0;
+    for (let j = jFrom; j < jTo; ++j) {
+        const jj = j * dim1;
+        for (let i = iFrom; i < iTo; ++i) {
+            tot += x[i + jj];
+        }
+    }
+    return tot;
+}
+
+export function odinSum3(x: number[], iFrom: number, iTo: number,
+                         jFrom: number, jTo: number, kFrom: number,
+                         kTo: number, dim1: number, dim12: number) {
+    let tot = 0.0;
+    for (let k = kFrom; k < kTo; ++k) {
+        const kk = k * dim12;
+        for (let j = jFrom; j < jTo; ++j) {
+            const jj = j * dim1 + kk;
+            for (let i = iFrom; i < iTo; ++i) {
+                tot += x[i + jj];
+            }
+        }
+    }
+    return tot;
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -42,7 +42,7 @@ export function delay(solution: Solution, t: number, index: number[],
 
 export const base = {checkUser: userHelpers.checkUser,
                      delay,
-                     getUserScalar: userHelpers.getUserScalar};
+                     setUserScalar: userHelpers.setUserScalar};
 
 // tslint:disable-next-line:variable-name
 export function wodinRun(Model: OdinModelConstructable, pars: UserType,

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,4 +1,9 @@
-export type UserType = Map<string, number>;
+export interface UserTensor {
+    data: number[];
+    dim: number[];
+}
+export type UserValue = number | number[] | UserTensor;
+export type UserType = Map<string, UserValue>;
 export type InternalStorage = Record<string, number | number[]>;
 
 export function checkUser(user: UserType, allowed: string[],
@@ -28,8 +33,8 @@ export function checkUser(user: UserType, allowed: string[],
 
 export function getUserScalar(user: UserType, name: string,
                               internal: InternalStorage,
-                              defaultValue: number | null, min: number | null,
-                              max: number | null, isInteger: boolean) {
+                              defaultValue: number | null, min: number,
+                              max: number, isInteger: boolean) {
     const value = user.get(name);
     if (value === undefined) {
         if (defaultValue === null) {
@@ -38,15 +43,112 @@ export function getUserScalar(user: UserType, name: string,
             internal[name] = defaultValue;
         }
     } else {
-        if (min !== null && value < min) {
-            throw Error(`Expected '${name}' to be at least ${min}`);
+        if (typeof value !== "number") {
+            throw Error(`Expected a scalar for '${name}'`);
         }
-        if (max !== null && value > max) {
-            throw Error(`Expected '${name}' to be at most ${max}`);
-        }
-        if (isInteger && !Number.isInteger(value)) {
-            throw Error(`Expected '${name}' to be integer-like`);
-        }
+        getUserCheckValue(value, min, max, isInteger, name);
         internal[name] = value;
+    }
+}
+
+export function getUserArrayFixed(user: UserType, name: string,
+                                  internal: InternalStorage,
+                                  size: number[],
+                                  min: number,
+                                  max: number,
+                                  isInteger: boolean) {
+    let value = user.get(name);
+    if (value === undefined) {
+        throw Error("Expected a value for '" + name + "'");
+    } else {
+        const rank = size.length - 1;
+        value = getUserArrayCheckType(value, name);
+        getUserArrayCheckRank(rank, value, name);
+        getUserArrayCheckDimension(size, value, name);
+        getUserArrayCheckContents(value, min, max, isInteger, name);
+        internal[name] = value.data.slice();
+    }
+}
+
+export function getUserArrayVarible(user: UserType, name: string,
+                                    internal: InternalStorage,
+                                    size: number[],
+                                    min: number,
+                                    max: number,
+                                    isInteger: boolean) {
+    let value = user.get(name);
+    if (value === undefined) {
+        throw Error("Expected a value for '" + name + "'");
+    } else {
+        const rank = size.length - 1;
+        value = getUserArrayCheckType(value, name);
+        getUserArrayCheckRank(rank, value, name);
+        getUserArrayCheckContents(value, min, max, isInteger, name);
+        size[0] = value.data.length;
+        for (let i = 0; i < rank; ++i) {
+            size[i + 1] = value.dim[i];
+        }
+        internal[name] = value.data.slice();
+    }
+}
+
+function getUserArrayCheckType(value: UserValue, name: string) {
+    if (Array.isArray(value)) {
+        value = {data: value, dim: [value.length]};
+    } else if (typeof value === "number") {
+        // promote scalar number to vector, in the hope that's close
+        // enough to what the user wants; this does give some
+        // reasonable error messages relative to the C version.
+        value = {data: [value], dim: [1]}
+    }
+    return value;
+}
+
+function getUserArrayCheckRank(rank: number, value: UserTensor, name: string) {
+    if (value.dim.length !== rank) {
+        if (rank === 1) {
+            throw Error(`Expected a numeric vector for '${name}'`);
+        } else if (rank === 2) {
+            throw Error(`Expected a numeric matrix for '${name}'`);
+        } else {
+            throw Error(`Expected a numeric array of rank ${rank} for '${name}'`);
+        }
+    }
+}
+
+function getUserArrayCheckDimension(dim: number[], value: UserTensor,
+                                    name: string) {
+    const rank = dim.length;
+    for (let i = 0; i < rank; ++i) {
+        const expected = dim[i + 1];
+        if (value.dim[i] !== expected) {
+            if (rank == 1) {
+                throw Error(`Expected length ${expected} value for '${name}'`);
+            } else {
+                throw Error(`Incorrect size of dimension ${i + 1} of '${name}' (expected ${expected})`);
+            }
+        }
+    }
+}
+
+function getUserArrayCheckContents(value: UserTensor, min: number, max: number, isInteger: boolean, name: string) {
+    for (let i = 0; i < value.data.length; ++i) {
+        const x = value.data[i];
+        if (x === null) {
+            throw Error(`'${name}' must not contain any NA values`);
+        }
+        getUserCheckValue(x, min, max, isInteger, name);
+    }
+}
+
+function getUserCheckValue(value: number, min: number, max: number, isInteger: boolean, name: string) {
+    if (value < min) {
+        throw Error(`Expected '${name}' to be at least ${min}`);
+    }
+    if (value > max) {
+        throw Error(`Expected '${name}' to be at most ${max}`);
+    }
+    if (isInteger && !Number.isInteger(value)) {
+        throw Error(`Expected an integer value for '${name}'`);
     }
 }

--- a/src/user.ts
+++ b/src/user.ts
@@ -31,7 +31,7 @@ export function checkUser(user: UserType, allowed: string[],
     }
 }
 
-export function getUserScalar(user: UserType, name: string,
+export function setUserScalar(user: UserType, name: string,
                               internal: InternalStorage,
                               defaultValue: number | null, min: number,
                               max: number, isInteger: boolean) {
@@ -47,12 +47,12 @@ export function getUserScalar(user: UserType, name: string,
         if (typeof value !== "number") {
             throw Error(`Expected a scalar for '${name}'`);
         }
-        getUserCheckValue(value, min, max, isInteger, name);
+        setUserCheckValue(value, min, max, isInteger, name);
         internal[name] = value;
     }
 }
 
-export function getUserArrayFixed(user: UserType, name: string,
+export function setUserArrayFixed(user: UserType, name: string,
                                   internal: InternalStorage,
                                   size: number[],
                                   min: number,
@@ -64,10 +64,10 @@ export function getUserArrayFixed(user: UserType, name: string,
         throw Error(`Expected a value for '${name}'`);
     } else {
         const rank = size.length - 1;
-        value = getUserArrayCheckType(value, name);
-        getUserArrayCheckRank(rank, value, name);
-        getUserArrayCheckDimension(size, value, name);
-        getUserArrayCheckContents(value, min, max, isInteger, name);
+        value = setUserArrayCheckType(value, name);
+        setUserArrayCheckRank(rank, value, name);
+        setUserArrayCheckDimension(size, value, name);
+        setUserArrayCheckContents(value, min, max, isInteger, name);
         internal[name] = value.data.slice();
     }
 }
@@ -81,7 +81,7 @@ export function getUserArrayFixed(user: UserType, name: string,
 // back into the size variable. odin will then generate code that sets
 // the appropriate sizes into 'internal' later - we might move that
 // into here later.
-export function getUserArrayVariable(user: UserType, name: string,
+export function setUserArrayVariable(user: UserType, name: string,
                                      internal: InternalStorage,
                                      size: number[],
                                      min: number,
@@ -92,9 +92,9 @@ export function getUserArrayVariable(user: UserType, name: string,
         throw Error("Expected a value for '" + name + "'");
     } else {
         const rank = size.length - 1;
-        value = getUserArrayCheckType(value, name);
-        getUserArrayCheckRank(rank, value, name);
-        getUserArrayCheckContents(value, min, max, isInteger, name);
+        value = setUserArrayCheckType(value, name);
+        setUserArrayCheckRank(rank, value, name);
+        setUserArrayCheckContents(value, min, max, isInteger, name);
         size[0] = value.data.length;
         for (let i = 0; i < rank; ++i) {
             size[i + 1] = value.dim[i];
@@ -103,7 +103,7 @@ export function getUserArrayVariable(user: UserType, name: string,
     }
 }
 
-function getUserArrayCheckType(value: UserValue, name: string) {
+function setUserArrayCheckType(value: UserValue, name: string) {
     if (Array.isArray(value)) {
         value = {data: value, dim: [value.length]};
     } else if (typeof value === "number") {
@@ -115,7 +115,7 @@ function getUserArrayCheckType(value: UserValue, name: string) {
     return value;
 }
 
-function getUserArrayCheckRank(rank: number, value: UserTensor, name: string) {
+function setUserArrayCheckRank(rank: number, value: UserTensor, name: string) {
     if (value.dim.length !== rank) {
         if (rank === 1) {
             throw Error(`Expected a numeric vector for '${name}'`);
@@ -127,7 +127,7 @@ function getUserArrayCheckRank(rank: number, value: UserTensor, name: string) {
     }
 }
 
-function getUserArrayCheckDimension(dim: number[], value: UserTensor,
+function setUserArrayCheckDimension(dim: number[], value: UserTensor,
                                     name: string) {
     const rank = dim.length - 1;
     for (let i = 0; i < rank; ++i) {
@@ -142,16 +142,16 @@ function getUserArrayCheckDimension(dim: number[], value: UserTensor,
     }
 }
 
-function getUserArrayCheckContents(value: UserTensor, min: number, max: number, isInteger: boolean, name: string) {
+function setUserArrayCheckContents(value: UserTensor, min: number, max: number, isInteger: boolean, name: string) {
     for (const x of value.data) {
         if (x === null) {
             throw Error(`'${name}' must not contain any NA values`);
         }
-        getUserCheckValue(x, min, max, isInteger, name);
+        setUserCheckValue(x, min, max, isInteger, name);
     }
 }
 
-function getUserCheckValue(value: number, min: number, max: number, isInteger: boolean, name: string) {
+function setUserCheckValue(value: number, min: number, max: number, isInteger: boolean, name: string) {
     if (value < min) {
         throw Error(`Expected '${name}' to be at least ${min}`);
     }

--- a/src/user.ts
+++ b/src/user.ts
@@ -37,6 +37,7 @@ export function getUserScalar(user: UserType, name: string,
                               max: number, isInteger: boolean) {
     const value = user.get(name);
     if (value === undefined) {
+        // TODO: pull values out of internals
         if (defaultValue === null) {
             throw Error(`Expected a value for '${name}'`);
         } else {
@@ -59,6 +60,7 @@ export function getUserArrayFixed(user: UserType, name: string,
                                   isInteger: boolean) {
     let value = user.get(name);
     if (value === undefined) {
+        // TODO: pull value out of internals
         throw Error("Expected a value for '" + name + "'");
     } else {
         const rank = size.length - 1;
@@ -108,7 +110,7 @@ function getUserArrayCheckType(value: UserValue, name: string) {
         // promote scalar number to vector, in the hope that's close
         // enough to what the user wants; this does give some
         // reasonable error messages relative to the C version.
-        value = {data: [value], dim: [1]}
+        value = {data: [value], dim: [1]};
     }
     return value;
 }
@@ -131,7 +133,7 @@ function getUserArrayCheckDimension(dim: number[], value: UserTensor,
     for (let i = 0; i < rank; ++i) {
         const expected = dim[i + 1];
         if (value.dim[i] !== expected) {
-            if (rank == 1) {
+            if (rank === 1) {
                 throw Error(`Expected length ${expected} value for '${name}'`);
             } else {
                 throw Error(`Incorrect size of dimension ${i + 1} of '${name}' (expected ${expected})`);
@@ -141,8 +143,7 @@ function getUserArrayCheckDimension(dim: number[], value: UserTensor,
 }
 
 function getUserArrayCheckContents(value: UserTensor, min: number, max: number, isInteger: boolean, name: string) {
-    for (let i = 0; i < value.data.length; ++i) {
-        const x = value.data[i];
+    for (const x of value.data) {
         if (x === null) {
             throw Error(`'${name}' must not contain any NA values`);
         }

--- a/src/user.ts
+++ b/src/user.ts
@@ -61,7 +61,7 @@ export function getUserArrayFixed(user: UserType, name: string,
     let value = user.get(name);
     if (value === undefined) {
         // TODO: pull value out of internals
-        throw Error("Expected a value for '" + name + "'");
+        throw Error(`Expected a value for '${name}'`);
     } else {
         const rank = size.length - 1;
         value = getUserArrayCheckType(value, name);

--- a/src/user.ts
+++ b/src/user.ts
@@ -70,12 +70,21 @@ export function getUserArrayFixed(user: UserType, name: string,
     }
 }
 
-export function getUserArrayVarible(user: UserType, name: string,
-                                    internal: InternalStorage,
-                                    size: number[],
-                                    min: number,
-                                    max: number,
-                                    isInteger: boolean) {
+// This one is used where we have
+//
+//   dim(x) <- user()
+//
+// which means that the extents are set based on the given array
+// (rather than some known value within size) and we report the values
+// back into the size variable. odin will then generate code that sets
+// the appropriate sizes into 'internal' later - we might move that
+// into here later.
+export function getUserArrayVariable(user: UserType, name: string,
+                                     internal: InternalStorage,
+                                     size: number[],
+                                     min: number,
+                                     max: number,
+                                     isInteger: boolean) {
     let value = user.get(name);
     if (value === undefined) {
         throw Error("Expected a value for '" + name + "'");
@@ -118,7 +127,7 @@ function getUserArrayCheckRank(rank: number, value: UserTensor, name: string) {
 
 function getUserArrayCheckDimension(dim: number[], value: UserTensor,
                                     name: string) {
-    const rank = dim.length;
+    const rank = dim.length - 1;
     for (let i = 0; i < rank; ++i) {
         const expected = dim[i + 1];
         if (value.dim[i] !== expected) {
@@ -149,6 +158,6 @@ function getUserCheckValue(value: number, min: number, max: number, isInteger: b
         throw Error(`Expected '${name}' to be at most ${max}`);
     }
     if (isInteger && !Number.isInteger(value)) {
-        throw Error(`Expected an integer value for '${name}'`);
+        throw Error(`Expected '${name}' to be integer-like`);
     }
 }

--- a/test/maths.test.ts
+++ b/test/maths.test.ts
@@ -1,4 +1,4 @@
-import {intdivr, modr, round2} from "../src/maths";
+import {intdivr, modr, round2, odinSum1, odinSum2, odinSum3} from "../src/maths";
 
 describe("round2", () => {
     it("rounds to even away", () => {
@@ -27,7 +27,6 @@ describe("modr", () => {
     })
 });
 
-
 describe("integer division", () => {
     it("works with all signs", () => {
         expect(intdivr(13, 7)).toEqual(1);
@@ -35,4 +34,33 @@ describe("integer division", () => {
         expect(intdivr(-13, 7)).toEqual(-2);
         expect(intdivr(-13, -7)).toEqual(1);
     })
+});
+
+describe("sums", () => {
+    it("Can sum over a vector", () => {
+        const x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        expect(odinSum1(x, 0, 10)).toEqual(55);
+        expect(odinSum1(x, 3, 5)).toEqual(9);
+    });
+
+    it("Can sum over a matrix", () => {
+        const x = [1, 2, 3, 4, 5, 6];
+        const nr = 2;
+        expect(odinSum2(x, 0, 1, 0, 3, nr)).toEqual(9);
+        expect(odinSum2(x, 1, 2, 0, 3, nr)).toEqual(12);
+        expect(odinSum2(x, 0, 2, 0, 3, nr)).toEqual(21);
+        expect(odinSum2(x, 0, 2, 0, 1, nr)).toEqual(3);
+        expect(odinSum2(x, 0, 2, 1, 2, nr)).toEqual(7);
+        expect(odinSum2(x, 0, 2, 2, 3, nr)).toEqual(11);
+    });
+
+    it("Can sum over a 3d array", () => {
+        const x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        const nr = 2;
+        const nc = 3;
+        expect(odinSum3(x, 0, 1, 0, 1, 0, 2, nr, nc * nr)).toEqual(8);
+        expect(odinSum3(x, 0, 1, 0, 3, 0, 2, nr, nc * nr)).toEqual(36);
+        expect(odinSum3(x, 0, 2, 0, 3, 0, 2, nr, nc * nr)).toEqual(78);
+        expect(odinSum3(x, 0, 2, 0, 1, 0, 2, nr, nc * nr)).toEqual(18);
+    });
 });

--- a/test/models.ts
+++ b/test/models.ts
@@ -106,7 +106,8 @@ export class User {
     setUser(user, unusedUserAction) {
         const internal = this.internal;
         this.base.checkUser(user, ["a"], unusedUserAction);
-        this.base.getUserScalar(user, "a", internal, 1, null, null, false);
+        this.base.getUserScalar(user, "a", internal, 1,
+                                -Infinity, Infinity, false);
         this.updateMetadata();
     }
 }
@@ -155,7 +156,8 @@ export class Output {
     setUser(user, unusedUserAction) {
         var internal = this.internal;
         this.base.checkUser(user, ["a"], unusedUserAction);
-        this.base.getUserScalar(user, "a", internal, 1, null, null, false);
+        this.base.getUserScalar(user, "a", internal, 1,
+                                -Infinity, Infinity, false);
         this.updateMetadata();
     }
 }

--- a/test/models.ts
+++ b/test/models.ts
@@ -106,7 +106,7 @@ export class User {
     setUser(user, unusedUserAction) {
         const internal = this.internal;
         this.base.checkUser(user, ["a"], unusedUserAction);
-        this.base.getUserScalar(user, "a", internal, 1,
+        this.base.setUserScalar(user, "a", internal, 1,
                                 -Infinity, Infinity, false);
         this.updateMetadata();
     }
@@ -156,7 +156,7 @@ export class Output {
     setUser(user, unusedUserAction) {
         var internal = this.internal;
         this.base.checkUser(user, ["a"], unusedUserAction);
-        this.base.getUserScalar(user, "a", internal, 1,
+        this.base.setUserScalar(user, "a", internal, 1,
                                 -Infinity, Infinity, false);
         this.updateMetadata();
     }

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -1,4 +1,4 @@
-import {InternalStorage, UserTensor, UserValue, checkUser, getUserScalar, getUserArrayFixed, getUserArrayVariable} from "../src/user";
+import {InternalStorage, UserTensor, UserValue, checkUser, setUserScalar, setUserArrayFixed, setUserArrayVariable} from "../src/user";
 
 describe("checkUser", () => {
     const pars = new Map<string, UserValue>([["a", 1], ["b", 2], ["c", 3]]);
@@ -40,44 +40,44 @@ describe("checkUser", () => {
     })
 });
 
-describe("getUserScalar", () => {
+describe("setUserScalar", () => {
     const pars = new Map<string, UserValue>([["a", 1], ["b", 2.5], ["c", 3]]);
     it("Can retrieve a user value", () => {
         const internal = {} as InternalStorage;
-        getUserScalar(pars, "a", internal, null, -Infinity, Infinity, false);
+        setUserScalar(pars, "a", internal, null, -Infinity, Infinity, false);
         expect(internal["a"]).toEqual(1);
     });
 
     it("Can fall back on default value, erroring if unavailable", () => {
         const internal = {} as InternalStorage;
-        getUserScalar(pars, "d", internal, 1, -Infinity, Infinity, false);
+        setUserScalar(pars, "d", internal, 1, -Infinity, Infinity, false);
         expect(internal["d"]).toEqual(1);
-        expect(() => getUserScalar(pars, "d", internal, null, -Infinity, Infinity, false))
+        expect(() => setUserScalar(pars, "d", internal, null, -Infinity, Infinity, false))
             .toThrow("Expected a value for 'd'");
     });
 
     it("Can validate that the provided value satisfies constraints", () => {
         const internal = {} as InternalStorage;
-        getUserScalar(pars, "a", internal, null, 0, 2, false);
+        setUserScalar(pars, "a", internal, null, 0, 2, false);
         expect(internal["a"]).toEqual(1);
-        expect(() => getUserScalar(pars, "a", internal, null, 2, 4, false))
+        expect(() => setUserScalar(pars, "a", internal, null, 2, 4, false))
             .toThrow("Expected 'a' to be at least 2");
-        expect(() => getUserScalar(pars, "a", internal, null, -2, 0, false))
+        expect(() => setUserScalar(pars, "a", internal, null, -2, 0, false))
             .toThrow("Expected 'a' to be at most 0");
-        expect(() => getUserScalar(pars, "b", internal, null, -Infinity, Infinity, true))
+        expect(() => setUserScalar(pars, "b", internal, null, -Infinity, Infinity, true))
             .toThrow("Expected 'b' to be integer-like");
     });
 
     it("Errors if given something other than a number", () => {
         const pars = new Map<string, UserValue>([["a", [1, 2, 3]]]);
         const internal = {} as InternalStorage;
-        expect(() => getUserScalar(
+        expect(() => setUserScalar(
             pars, "a", internal, null, -Infinity, Infinity, false))
             .toThrow("Expected a scalar for 'a'");
     });
 });
 
-describe("getUserArrayFixed", () => {
+describe("setUserArrayFixed", () => {
     const pars = new Map<string, UserValue>([
         ["a", 1],
         ["b", [1, 2, 3]],
@@ -87,70 +87,70 @@ describe("getUserArrayFixed", () => {
     ]);
     it("Can retrieve a user array from a scalar", () => {
         const internal = {} as InternalStorage;
-        getUserArrayFixed(pars, "a", internal, [1, 1],
+        setUserArrayFixed(pars, "a", internal, [1, 1],
                           -Infinity, Infinity, false);
         expect(internal["a"]).toEqual([1]);
     });
     it("Can retrieve a user array from an array", () => {
         const internal = {} as InternalStorage;
-        getUserArrayFixed(pars, "b", internal, [3, 3],
+        setUserArrayFixed(pars, "b", internal, [3, 3],
                           -Infinity, Infinity, false);
         expect(internal["b"]).toEqual([1, 2, 3]);
     });
     it("Can retrieve a user array from a tensor", () => {
         const internal = {} as InternalStorage;
-        getUserArrayFixed(pars, "c", internal, [3, 3],
+        setUserArrayFixed(pars, "c", internal, [3, 3],
                           -Infinity, Infinity, false);
         expect(internal["c"]).toEqual([1, 2, 3]);
     });
     it("Can retrieve a user matrix from a tensor", () => {
         const internal = {} as InternalStorage;
-        getUserArrayFixed(pars, "d", internal, [6, 2, 3],
+        setUserArrayFixed(pars, "d", internal, [6, 2, 3],
                           -Infinity, Infinity, false);
         expect(internal["d"]).toEqual([1, 2, 3, 4, 5, 6]);
     });
     it("Can retrieve a user 3d array from a tensor", () => {
         const internal = {} as InternalStorage;
-        getUserArrayFixed(pars, "e", internal, [12, 2, 3, 2],
+        setUserArrayFixed(pars, "e", internal, [12, 2, 3, 2],
                           -Infinity, Infinity, false);
         expect(internal["e"]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     });
     it("Errors if a value is not found", () => {
         const internal = {} as InternalStorage;
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "x", internal, [3, 3], -Infinity, Infinity, false))
             .toThrow("Expected a value for 'x'");
     });
     it("Errors if provided with the wrong rank", () => {
         const internal = {} as InternalStorage;
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "d", internal, [3, 3], -Infinity, Infinity, false))
             .toThrow("Expected a numeric vector for 'd'");
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "c", internal, [6, 2, 3], -Infinity, Infinity, false))
             .toThrow("Expected a numeric matrix for 'c'");
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "d", internal, [12, 2, 3, 2], -Infinity, Infinity, false))
             .toThrow("Expected a numeric array of rank 3 for 'd'");
     });
     it("Errors if provided with the wrong size", () => {
         const internal = {} as InternalStorage;
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "b", internal, [4, 4], -Infinity, Infinity, false))
             .toThrow("Expected length 4 value for 'b'");
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "d", internal, [10, 2, 5], -Infinity, Infinity, false))
             .toThrow("Incorrect size of dimension 2 of 'd' (expected 5)");
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "d", internal, [12, 4, 3], -Infinity, Infinity, false))
             .toThrow("Incorrect size of dimension 1 of 'd' (expected 4)");
     });
     it("Errors if values are out of range", () => {
         const internal = {} as InternalStorage;
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "c", internal, [3, 3], 2, Infinity, false))
             .toThrow("Expected 'c' to be at least 2");
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "c", internal, [3, 3], -Infinity, 2, false))
             .toThrow("Expected 'c' to be at most 2");
     });
@@ -160,13 +160,13 @@ describe("getUserArrayFixed", () => {
         const pars = new Map<string, UserValue>([
             ["x", {data: [1, 2, null as any], dim: [3]}]
         ]);
-        expect(() => getUserArrayFixed(
+        expect(() => setUserArrayFixed(
             pars, "x", internal, [3, 3], -Infinity, Infinity, false))
             .toThrow("'x' must not contain any NA values");
     });
 });
 
-describe("getUserArrayFixed", () => {
+describe("setUserArrayFixed", () => {
     const pars = new Map<string, UserValue>([
         ["a", 1],
         ["b", [1, 2, 3]],
@@ -177,7 +177,7 @@ describe("getUserArrayFixed", () => {
     it("Can fetch a variable and save sizes", () => {
         const size = [0, 0, 0];
         const internal = {} as InternalStorage;
-        getUserArrayVariable(pars, "d", internal, size,
+        setUserArrayVariable(pars, "d", internal, size,
                              -Infinity, Infinity, false);
         expect(internal.d).toEqual([1, 2, 3, 4, 5, 6]);
         expect(size).toEqual([6, 2, 3]);
@@ -185,7 +185,7 @@ describe("getUserArrayFixed", () => {
     it("Errors if a value is not found", () => {
         const internal = {} as InternalStorage;
         const size = [0, 0];
-        expect(() => getUserArrayVariable(
+        expect(() => setUserArrayVariable(
             pars, "x", internal, size, -Infinity, Infinity, false))
             .toThrow("Expected a value for 'x'");
     });


### PR DESCRIPTION
This PR includes all remaining functions from odin's [`inst/js/support.js`](https://github.com/mrc-ide/odin/blob/mrc-3182/inst/js/support.js) except only sum functions up to 3d arrays. These are unit tested here but not made available to the model runner as I'll rejig that later in a smaller PR.

The next step after this will be to make sure that the odin package can run this code through the test suite, then we can start work on the fitting and sensitivity output.