### PR TITLE
Reorganise code to support both odin and wodin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## wodin support
 
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
-[![build status](https://github.com/mrc-ide/wodin-runner/workflows/ci/badge.svg)](https://github.com/mrc-ide/wodin-runner/actions)
-[![codecov.io](https://codecov.io/github/mrc-ide/wodin-runner/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/wodin-runner?branch=master)
+[![build status](https://github.com/mrc-ide/odin-js/workflows/ci/badge.svg)](https://github.com/mrc-ide/odin-js/actions)
+[![codecov.io](https://codecov.io/github/mrc-ide/odin-js/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/odin-js?branch=main)
 
 ## Licence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "wodin-runner",
+    "name": "@reside-ic/odin",
     "version": "0.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "wodin-runner",
+            "name": "@reside-ic/odin",
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "wodin-runner",
+    "name": "@reside-ic/odin",
     "version": "0.0.1",
-    "description": "Wodin support",
+    "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "files": [
@@ -15,14 +15,14 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mrc-ide/wodin-runner.git"
+        "url": "git+https://github.com/mrc-ide/odin-js.git"
     },
     "author": "Rich FitzJohn <rich.fitzjohn@gmail.com>",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/mrc-ide/wodin-runner/issues"
+        "url": "https://github.com/mrc-ide/odin-js/issues"
     },
-    "homepage": "https://github.com/mrc-ide/wodin-runner#readme",
+    "homepage": "https://github.com/mrc-ide/odin-js#readme",
     "devDependencies": {
         "@types/jest": "^27.5.1",
         "jest": "^28.0.0",

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,0 +1,5 @@
+import {delay} from "./delay";
+import * as maths from "./maths";
+import * as user from "./user";
+
+export {delay, maths, user};

--- a/src/delay.ts
+++ b/src/delay.ts
@@ -1,6 +1,4 @@
-// Probably this is something that dopri should export for us, we
-// could also use its types for the rhs and output members below.
-export type Solution = (t: number) => number[];
+import {Solution} from "./model";
 
 export function delay(solution: Solution, t: number, index: number[],
                       state: number[]) {

--- a/src/delay.ts
+++ b/src/delay.ts
@@ -1,0 +1,14 @@
+// Probably this is something that dopri should export for us, we
+// could also use its types for the rhs and output members below.
+export type Solution = (t: number) => number[];
+
+export function delay(solution: Solution, t: number, index: number[],
+                      state: number[]) {
+    // Later, we'll update dopri.js to allow passing index here,
+    // which will make this more efficient. However, no change to
+    // the external interface will be neeed.
+    const y = solution(t);
+    for (let i = 0; i < index.length; ++i) {
+        state[i] = y[index[i]];
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export {wodinRun} from "./runner";
+export {wodinRun} from "./wodin";
+export {PkgWrapper} from "./pkg";

--- a/src/model.ts
+++ b/src/model.ts
@@ -92,6 +92,10 @@ function runModelDDE(model: OdinModelDDE, y0: number[] | null,
     if (y0 === null) {
         y0 = model.initial(tStart);
     }
+
+    const internal = model.getInternal();
+    internal["initial_t"] = tStart;
+
     const solver = new dopri.DDE(rhs, y0.length, control, output);
     solver.initialise(tStart, y0);
     return {solution: solver.run(tEnd),

--- a/src/model.ts
+++ b/src/model.ts
@@ -94,7 +94,7 @@ function runModelDDE(model: OdinModelDDE, y0: number[] | null,
     }
 
     const internal = model.getInternal();
-    internal["initial_t"] = tStart;
+    internal.initial_t = tStart;
 
     const solver = new dopri.DDE(rhs, y0.length, control, output);
     solver.initialise(tStart, y0);

--- a/src/model.ts
+++ b/src/model.ts
@@ -10,6 +10,7 @@ export type OdinModelConstructable =
     new(base: any, pars: UserType, unknownAction: string) => OdinModel;
 
 interface OdinModelODE {
+    setUser(pars: UserType, unknownAction: string): void;
     initial(t: number): number[];
     rhs(t: number, y: number[], dydt: number[]): void;
     output?(t: number, y: number[]): number[];
@@ -19,6 +20,7 @@ interface OdinModelODE {
 }
 
 interface OdinModelDDE {
+    setUser(pars: UserType, unknownAction: string): void;
     initial(t: number): number[];
     rhs(t: number, y: number[], dydt: number[], solution: Solution): void;
     output?(t: number, y: number[], solution: Solution): number[];

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -39,6 +39,10 @@ export class PkgWrapper {
         return this.model.getInternal();
     }
 
+    public setUser(pars: UserType, unusedUserAction: string) {
+        this.model.setUser(pars, unusedUserAction);
+    }
+
     public run(t: number[], y0: number[] | null, control: any) {
         const tStart = t[0];
         const tEnd = t[t.length - 1];

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -1,0 +1,50 @@
+import * as base from "./base";
+import type { OdinModel, OdinModelConstructable, Solution } from "./model";
+import {isODEModel, runModel} from "./model";
+import type { UserType } from "./user";
+
+export class PkgWrapper {
+    private model: OdinModel;
+
+    // tslint:disable-next-line:variable-name
+    constructor(Model: OdinModelConstructable, pars: UserType, unusedUserAction: string) {
+        this.model = new Model(base, pars, unusedUserAction);
+    }
+
+    public initial(t: number) {
+        return this.model.initial(t);
+    }
+
+    public rhs(t: number, y: number[]) {
+        const state = new Array(y.length).fill(0);
+        let output = null;
+
+        if (isODEModel(this.model)) {
+            const model = this.model;
+            this.model.rhs(t, y, state);
+            if (this.model.output) {
+                output = this.model.output(t, y);
+            }
+        } else {
+            throw Error("Can't use rhs() with delay models");
+        }
+        return {output, state};
+    }
+
+    public getMetadata() {
+        return this.model.getMetadata();
+    }
+
+    public getInternal() {
+        return this.model.getInternal();
+    }
+
+    public run(t: number[], y0: number[], control: any) {
+        const tStart = t[0];
+        const tEnd = t[t.length - 1];
+        const result = runModel(this.model, tStart, tEnd, control);
+        return {names: this.model.names(),
+                statistics: result.statistics,
+                y: result.solution(t)};
+    }
+}

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -39,10 +39,10 @@ export class PkgWrapper {
         return this.model.getInternal();
     }
 
-    public run(t: number[], y0: number[], control: any) {
+    public run(t: number[], y0: number[] | null, control: any) {
         const tStart = t[0];
         const tEnd = t[t.length - 1];
-        const result = runModel(this.model, tStart, tEnd, control);
+        const result = runModel(this.model, y0, tStart, tEnd, control);
         return {names: this.model.names(),
                 statistics: result.statistics,
                 y: result.solution(t)};

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,13 +1,11 @@
 import * as dopri from "dopri";
-import type { UserType } from "./user";
-import * as userHelpers from "./user";
 
-// Probably this is something that dopri should export for us, we
-// could also use its types for the rhs and output members below.
-type Solution = (t: number) => number[];
+import * as base from "./base";
+import type { Solution } from "./delay";
+import type { UserType } from "./user";
 
 export type OdinModelConstructable =
-    new(userHelpers: any, pars: UserType, unknownAction: string) => OdinModel;
+    new(base: any, pars: UserType, unknownAction: string) => OdinModel;
 
 interface OdinModelODE {
     initial(t: number): number[];
@@ -28,21 +26,6 @@ function isDDEModel(model: OdinModel): model is OdinModelDDE {
 }
 
 export type OdinModel = OdinModelODE | OdinModelDDE;
-
-export function delay(solution: Solution, t: number, index: number[],
-                      state: number[]) {
-    // Later, we'll update dopri.js to allow passing index here,
-    // which will make this more efficient. However, no change to
-    // the external interface will be neeed.
-    const y = solution(t);
-    for (let i = 0; i < index.length; ++i) {
-        state[i] = y[index[i]];
-    }
-}
-
-export const base = {checkUser: userHelpers.checkUser,
-                     delay,
-                     setUserScalar: userHelpers.setUserScalar};
 
 // tslint:disable-next-line:variable-name
 export function wodinRun(Model: OdinModelConstructable, pars: UserType,

--- a/src/user.ts
+++ b/src/user.ts
@@ -37,12 +37,13 @@ export function setUserScalar(user: UserType, name: string,
                               max: number, isInteger: boolean) {
     const value = user.get(name);
     if (value === undefined) {
-        // TODO: pull values out of internals
+        if (internal[name] !== undefined) {
+            return;
+        }
         if (defaultValue === null) {
             throw Error(`Expected a value for '${name}'`);
-        } else {
-            internal[name] = defaultValue;
         }
+        internal[name] = defaultValue;
     } else {
         if (typeof value !== "number") {
             throw Error(`Expected a number for '${name}'`);
@@ -60,7 +61,9 @@ export function setUserArrayFixed(user: UserType, name: string,
                                   isInteger: boolean) {
     let value = user.get(name);
     if (value === undefined) {
-        // TODO: pull value out of internals
+        if (internal[name] !== undefined) {
+            return;
+        }
         throw Error(`Expected a value for '${name}'`);
     } else {
         const rank = size.length - 1;
@@ -89,6 +92,9 @@ export function setUserArrayVariable(user: UserType, name: string,
                                      isInteger: boolean) {
     let value = user.get(name);
     if (value === undefined) {
+        if (internal[name] !== undefined) {
+            return;
+        }
         throw Error("Expected a value for '" + name + "'");
     } else {
         const rank = size.length - 1;

--- a/src/user.ts
+++ b/src/user.ts
@@ -45,7 +45,7 @@ export function setUserScalar(user: UserType, name: string,
         }
     } else {
         if (typeof value !== "number") {
-            throw Error(`Expected a scalar for '${name}'`);
+            throw Error(`Expected a number for '${name}'`);
         }
         setUserCheckValue(value, min, max, isInteger, name);
         internal[name] = value;

--- a/src/user.ts
+++ b/src/user.ts
@@ -158,6 +158,10 @@ function setUserArrayCheckContents(value: UserTensor, min: number, max: number, 
 }
 
 function setUserCheckValue(value: number, min: number, max: number, isInteger: boolean, name: string) {
+    // This exists to make the plain js interface more robust
+    if (typeof value !== "number") {
+        throw Error(`Expected a number for '${name}'`);
+    }
     if (value < min) {
         throw Error(`Expected '${name}' to be at least ${min}`);
     }

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -1,0 +1,29 @@
+import * as base from "./base";
+import type { OdinModelConstructable, Solution } from "./model";
+import {runModel} from "./model";
+import type { UserType } from "./user";
+
+// tslint:disable-next-line:variable-name
+export function wodinRun(Model: OdinModelConstructable, pars: UserType,
+                         tStart: number, tEnd: number,
+                         control: any) {
+    const model = new Model(base, pars, "error");
+    const solution = runModel(model, tStart, tEnd, control).solution;
+    const names = model.names();
+    return (t0: number, t1: number, nPoints: number) => {
+        const t = grid(Math.max(0, t0), Math.min(t1, tEnd), nPoints);
+        const y = solution(t);
+        return y[0].map((_: any, i: number) => ({
+            name: names[i], x: t, y: y.map((row: number[]) => row[i])}));
+    };
+}
+
+export function grid(a: number, b: number, len: number) {
+    const dx = (b - a) / (len - 1);
+    const x = [];
+    for (let i = 0; i < len - 1; ++i) {
+        x.push(a + i * dx);
+    }
+    x.push(b);
+    return x;
+}

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -8,7 +8,8 @@ export function wodinRun(Model: OdinModelConstructable, pars: UserType,
                          tStart: number, tEnd: number,
                          control: any) {
     const model = new Model(base, pars, "error");
-    const solution = runModel(model, tStart, tEnd, control).solution;
+    const y0 = null;
+    const solution = runModel(model, y0, tStart, tEnd, control).solution;
     const names = model.names();
     return (t0: number, t1: number, nPoints: number) => {
         const t = grid(Math.max(0, t0), Math.min(t1, tEnd), nPoints);

--- a/test/models.ts
+++ b/test/models.ts
@@ -105,9 +105,9 @@ export class User {
 
     setUser(user, unusedUserAction) {
         const internal = this.internal;
-        this.base.checkUser(user, ["a"], unusedUserAction);
-        this.base.setUserScalar(user, "a", internal, 1,
-                                -Infinity, Infinity, false);
+        this.base.user.checkUser(user, ["a"], unusedUserAction);
+        this.base.user.setUserScalar(user, "a", internal, 1,
+                                     -Infinity, Infinity, false);
         this.updateMetadata();
     }
 }
@@ -155,9 +155,9 @@ export class Output {
 
     setUser(user, unusedUserAction) {
         var internal = this.internal;
-        this.base.checkUser(user, ["a"], unusedUserAction);
-        this.base.setUserScalar(user, "a", internal, 1,
-                                -Infinity, Infinity, false);
+        this.base.user.checkUser(user, ["a"], unusedUserAction);
+        this.base.user.setUserScalar(user, "a", internal, 1,
+                                     -Infinity, Infinity, false);
         this.updateMetadata();
     }
 }
@@ -206,7 +206,7 @@ export class DelayNoOutput {
     }
 
     setUser(user, unusedUserAction) {
-        this.base.checkUser(user, [], unusedUserAction);
+        this.base.user.checkUser(user, [], unusedUserAction);
         this.updateMetadata();
     }
 

--- a/test/models.ts
+++ b/test/models.ts
@@ -23,6 +23,14 @@ export class Minimal {
     names() {
         return ["x"];
     }
+
+    getMetadata() {
+        return {};
+    }
+
+    getInternal() {
+        return this.internal;
+    }
 }
 
 // @ts-nocheck
@@ -67,6 +75,14 @@ export class Delay {
     names() {
         return ["x", "y"];
     }
+
+    getMetadata() {
+        return {};
+    }
+
+    getInternal() {
+        return this.internal;
+    }
 }
 
 // @ts-nocheck
@@ -109,6 +125,14 @@ export class User {
         this.base.user.setUserScalar(user, "a", internal, 1,
                                      -Infinity, Infinity, false);
         this.updateMetadata();
+    }
+
+    getMetadata() {
+        return this.metadata;
+    }
+
+    getInternal() {
+        return this.internal;
     }
 }
 
@@ -159,6 +183,14 @@ export class Output {
         this.base.user.setUserScalar(user, "a", internal, 1,
                                      -Infinity, Infinity, false);
         this.updateMetadata();
+    }
+
+    getMetadata() {
+        return this.metadata;
+    }
+
+    getInternal() {
+        return this.internal;
     }
 }
 
@@ -212,5 +244,13 @@ export class DelayNoOutput {
 
     names() {
         return this.metadata.ynames.slice(1);
+    }
+
+    getMetadata() {
+        return this.metadata;
+    }
+
+    getInternal() {
+        return this.internal;
     }
 }

--- a/test/models.ts
+++ b/test/models.ts
@@ -31,6 +31,9 @@ export class Minimal {
     getInternal() {
         return this.internal;
     }
+
+    setUser(user, unusedUserAction) {
+    }
 }
 
 // @ts-nocheck
@@ -82,6 +85,9 @@ export class Delay {
 
     getInternal() {
         return this.internal;
+    }
+
+    setUser(user, unusedUserAction) {
     }
 }
 

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -1,0 +1,37 @@
+import {PkgWrapper} from "../src/pkg";
+
+import * as models from "./models";
+import {approxEqualArray} from "./helpers";
+
+describe("wrapper", () => {
+    it("Can create a simple wrapped model", () => {
+        const user = new Map<string, number>();
+        const control : any = {};
+        const mod = new PkgWrapper(models.Minimal, user, "error");
+
+        expect(mod.initial(0)).toEqual([1]);
+        expect(mod.rhs(0, [1])).toEqual({"output": null, "state": [1]});
+        expect(mod.getMetadata()).toEqual({});
+        const internal = mod.getInternal();
+        expect(internal.a).toEqual(1);
+        const result = mod.run([0, 1, 2, 3], [1], control);
+        expect(result.y).toEqual([[1], [2], [3], [4]]);
+        expect(result.names).toEqual(["x"]);
+        expect(result.statistics.nEval).toBeGreaterThan(10);
+    });
+
+    it("Can run the rhs with output", () => {
+        const user = new Map<string, number>([["a", 1]]);
+        const control : any = {};
+        const mod = new PkgWrapper(models.Output, user, "error");
+        expect(mod.rhs(0, [1])).toEqual({"output": [2], "state": [1]});
+    });
+
+    it("Refuses to run rhs for dde models", () => {
+        const user = new Map<string, number>();
+        const control : any = {};
+        const mod = new PkgWrapper(models.Delay, user, "error");
+        expect(() => mod.rhs(0, [0])).toThrow(
+            "Can't use rhs() with delay models");
+    });
+});

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -46,4 +46,18 @@ describe("wrapper", () => {
         const y = result.y.map((el: number[]) => el[0]);
         expect(approxEqualArray(y, [2, 3, 4, 5, 6])).toBe(true);
     })
+
+    it("Can set user variables", () => {
+        const user = new Map<string, number>([["a", 1]]);
+        const control: any = {};
+        const mod = new PkgWrapper(models.User, user, "error");
+        const t = 0;
+        const y = [0];
+        expect(mod.rhs(t, y).state).toEqual([1]);
+        user.set("a", 2);
+        mod.setUser(user, "error");
+        expect(mod.rhs(t, y).state).toEqual([2]);
+        mod.setUser(new Map<string, number>(), "error");
+        expect(mod.rhs(t, y).state).toEqual([2]);
+    });
 });

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -14,7 +14,7 @@ describe("wrapper", () => {
         expect(mod.getMetadata()).toEqual({});
         const internal = mod.getInternal();
         expect(internal.a).toEqual(1);
-        const result = mod.run([0, 1, 2, 3], [1], control);
+        const result = mod.run([0, 1, 2, 3], null, control);
         expect(result.y).toEqual([[1], [2], [3], [4]]);
         expect(result.names).toEqual(["x"]);
         expect(result.statistics.nEval).toBeGreaterThan(10);
@@ -34,4 +34,16 @@ describe("wrapper", () => {
         expect(() => mod.rhs(0, [0])).toThrow(
             "Can't use rhs() with delay models");
     });
+
+    it("Can override the initial conditions", () => {
+        const user = new Map<string, number>();
+        const control : any = {};
+        const mod = new PkgWrapper(models.Minimal, user, "error");
+
+        const t = [0, 1, 2, 3, 4]
+        const result = mod.run(t, [2], control);
+
+        const y = result.y.map((el: number[]) => el[0]);
+        expect(approxEqualArray(y, [2, 3, 4, 5, 6])).toBe(true);
+    })
 });

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -170,6 +170,16 @@ describe("setUserArrayFixed", () => {
             .toThrow("'x' must not contain any NA values");
     });
 
+    it("Errors if given non-numeric data", () => {
+        const internal = {} as InternalStorage;
+        const pars = new Map<string, UserValue>([
+            ["x", {data: [1, 2, "three" as any], dim: [3]}]
+        ]);
+        expect(() => setUserArrayFixed(
+            pars, "x", internal, [3, 3], -Infinity, Infinity, false))
+            .toThrow("Expected a number for 'x'");
+    });
+
     it("Can fall back on existing values", () => {
         const internal = {x: [10, 11, 12]} as InternalStorage;
         setUserArrayFixed(pars, "x", internal, [3, 3],
@@ -178,7 +188,7 @@ describe("setUserArrayFixed", () => {
     });
 });
 
-describe("setUserArrayFixed", () => {
+describe("setUserArrayVariable", () => {
     const pars = new Map<string, UserValue>([
         ["a", 1],
         ["b", [1, 2, 3]],

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -50,10 +50,9 @@ describe("setUserScalar", () => {
 
     it("Can fall back on default value, erroring if unavailable", () => {
         const internal = {} as InternalStorage;
-        setUserScalar(pars, "d", internal, 1, -Infinity, Infinity, false);
-        expect(internal["d"]).toEqual(1);
         expect(() => setUserScalar(pars, "d", internal, null, -Infinity, Infinity, false))
             .toThrow("Expected a value for 'd'");
+        setUserScalar(pars, "d", internal, 1, -Infinity, Infinity, false);
     });
 
     it("Can validate that the provided value satisfies constraints", () => {
@@ -73,7 +72,7 @@ describe("setUserScalar", () => {
         const internal = {} as InternalStorage;
         expect(() => setUserScalar(
             pars, "a", internal, null, -Infinity, Infinity, false))
-            .toThrow("Expected a scalar for 'a'");
+            .toThrow("Expected a number for 'a'");
     });
 });
 

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -55,6 +55,12 @@ describe("setUserScalar", () => {
         setUserScalar(pars, "d", internal, 1, -Infinity, Infinity, false);
     });
 
+    it("Can fall back on value within internal if missing", () => {
+        const internal = {d: 10} as InternalStorage;
+        setUserScalar(pars, "d", internal, 1, -Infinity, Infinity, false);
+        expect(internal["d"]).toEqual(10);
+    });
+
     it("Can validate that the provided value satisfies constraints", () => {
         const internal = {} as InternalStorage;
         setUserScalar(pars, "a", internal, null, 0, 2, false);
@@ -163,6 +169,13 @@ describe("setUserArrayFixed", () => {
             pars, "x", internal, [3, 3], -Infinity, Infinity, false))
             .toThrow("'x' must not contain any NA values");
     });
+
+    it("Can fall back on existing values", () => {
+        const internal = {x: [10, 11, 12]} as InternalStorage;
+        setUserArrayFixed(pars, "x", internal, [3, 3],
+                          -Infinity, Infinity, false);
+        expect(internal["x"]).toEqual([10, 11, 12]);
+    });
 });
 
 describe("setUserArrayFixed", () => {
@@ -187,5 +200,12 @@ describe("setUserArrayFixed", () => {
         expect(() => setUserArrayVariable(
             pars, "x", internal, size, -Infinity, Infinity, false))
             .toThrow("Expected a value for 'x'");
+    });
+
+    it("Can fall back on existing values", () => {
+        const internal = {x: [10, 11, 12]} as InternalStorage;
+        setUserArrayVariable(pars, "x", internal, [3, 3],
+                          -Infinity, Infinity, false);
+        expect(internal["x"]).toEqual([10, 11, 12]);
     });
 });

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,4 +1,4 @@
-import {grid, wodinRun} from "../src/runner";
+import {grid, wodinRun} from "../src/wodin";
 import * as models from "./models";
 import {approxEqualArray} from "./helpers";
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,8 @@ module.exports = {
         extensions: ['.tsx', '.ts', '.js'],
     },
     output: {
-        library: 'wodinRunner',
-        filename: 'wodin-runner.js',
+        library: 'odin',
+        filename: 'odin.js',
         path: path.resolve(__dirname, 'dist'),
     },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
         extensions: ['.tsx', '.ts', '.js'],
     },
     output: {
-        library: 'odin',
+        library: 'odinjs',
         filename: 'odin.js',
         path: path.resolve(__dirname, 'dist'),
     },


### PR DESCRIPTION
Hopefully the last nasty one before we start iterating more sensibly.

This PR rearranges things so that there is a common runner function (see src/model.ts) and then interfaces that work from wodin (src/wodin.ts) and from the R package (src/pkg.ts) sharing as much code as possible.

Along the way there are quite a few little tweaks that were needed to actually support running the models from R - the results of this PR are the odin PR https://github.com/mrc-ide/odin/pull/264 which makes use of this package.

Once this is in we'll progress two ways:

* expand the package to support the missing features that we need from odin (notably discrete models which need a new running function but also interpolation functions which require another little js package)
* expand the functionality to suit wodin (notably fitting and sensitivity)
