### PR TITLE
Tidy up types in package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "dopri": "^0.0.9"
+                "dopri": "^0.0.11"
             },
             "devDependencies": {
                 "@types/jest": "^27.5.1",
@@ -1890,9 +1890,9 @@
             }
         },
         "node_modules/dopri": {
-            "version": "0.0.9",
-            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.9.tgz",
-            "integrity": "sha512-SseN+0BeV9ZhXHJlNOpPrXFNBGEjFS5h8X1xR3Ew4IvDvNz7lGyLYGOIVKcFT1kK8EpPjVhN6NroCKx+pWqe5g=="
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.11.tgz",
+            "integrity": "sha512-tXTmoud8up0zDI2PgUSMLJququ9I36+tfOT2Z6EW3k1x7QLl8y9cc/iXSxooFqKhzZPncIGsJk9b8sPEOMRSMg=="
         },
         "node_modules/electron-to-chromium": {
             "version": "1.4.150",
@@ -6463,9 +6463,9 @@
             "dev": true
         },
         "dopri": {
-            "version": "0.0.9",
-            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.9.tgz",
-            "integrity": "sha512-SseN+0BeV9ZhXHJlNOpPrXFNBGEjFS5h8X1xR3Ew4IvDvNz7lGyLYGOIVKcFT1kK8EpPjVhN6NroCKx+pWqe5g=="
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.11.tgz",
+            "integrity": "sha512-tXTmoud8up0zDI2PgUSMLJququ9I36+tfOT2Z6EW3k1x7QLl8y9cc/iXSxooFqKhzZPncIGsJk9b8sPEOMRSMg=="
         },
         "electron-to-chromium": {
             "version": "1.4.150",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "dopri": "^0.0.11"
+                "dopri": "^0.0.12"
             },
             "devDependencies": {
                 "@types/jest": "^27.5.1",
@@ -1890,9 +1890,9 @@
             }
         },
         "node_modules/dopri": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.11.tgz",
-            "integrity": "sha512-tXTmoud8up0zDI2PgUSMLJququ9I36+tfOT2Z6EW3k1x7QLl8y9cc/iXSxooFqKhzZPncIGsJk9b8sPEOMRSMg=="
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.12.tgz",
+            "integrity": "sha512-157lP/wj0HTvg/wwJnX4YVocvwBQKUaGSyyVNUtIftbZkABLFXnnwhoyhjpKbvRIvQF7NGAlthq/QjD6pz3WjQ=="
         },
         "node_modules/electron-to-chromium": {
             "version": "1.4.150",
@@ -6463,9 +6463,9 @@
             "dev": true
         },
         "dopri": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.11.tgz",
-            "integrity": "sha512-tXTmoud8up0zDI2PgUSMLJququ9I36+tfOT2Z6EW3k1x7QLl8y9cc/iXSxooFqKhzZPncIGsJk9b8sPEOMRSMg=="
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.12.tgz",
+            "integrity": "sha512-157lP/wj0HTvg/wwJnX4YVocvwBQKUaGSyyVNUtIftbZkABLFXnnwhoyhjpKbvRIvQF7NGAlthq/QjD6pz3WjQ=="
         },
         "electron-to-chromium": {
             "version": "1.4.150",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "dopri": "^0.0.11"
+        "dopri": "^0.0.12"
     }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "dopri": "^0.0.9"
+        "dopri": "^0.0.11"
     }
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -2,4 +2,5 @@ import {delay} from "./delay";
 import * as maths from "./maths";
 import * as user from "./user";
 
-export {delay, maths, user};
+export const base = {delay, maths, user};
+export type BaseType = typeof base;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,11 @@
 import * as dopri from "dopri";
 
+// Can't use export * as base shorthand here
+import * as base from "./base";
+export {base};
+
+export type BaseType = typeof base;
+
 import {InternalStorage, UserType} from "./user";
 
 // Probably this is something that dopri should export for us, we
@@ -7,7 +13,7 @@ import {InternalStorage, UserType} from "./user";
 export type Solution = (t: number) => number[];
 
 export type OdinModelConstructable =
-    new(base: any, pars: UserType, unknownAction: string) => OdinModel;
+    new(base: BaseType, pars: UserType, unknownAction: string) => OdinModel;
 
 interface OdinModelODE {
     setUser(pars: UserType, unknownAction: string): void;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,11 +1,7 @@
 import * as dopri from "dopri";
 import type { DopriControlParam } from "dopri";
 
-// Can't use export * as base shorthand here
-import * as base from "./base";
-export {base};
-
-export type BaseType = typeof base;
+import {base, BaseType} from "./base";
 
 import {InternalStorage, UserType} from "./user";
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,5 @@
 import * as dopri from "dopri";
+import type { DopriControlParam } from "dopri";
 
 // Can't use export * as base shorthand here
 import * as base from "./base";
@@ -47,14 +48,15 @@ export type OdinModel = OdinModelODE | OdinModelDDE;
 
 export function runModel(model: OdinModel, y0: number[] | null,
                          tStart: number, tEnd: number,
-                         control: any) {
+                         control: Partial<DopriControlParam>) {
     return isDDEModel(model) ?
         runModelDDE(model as OdinModelDDE, y0, tStart, tEnd, control) :
         runModelODE(model as OdinModelODE, y0, tStart, tEnd, control);
 }
 
 function runModelODE(model: OdinModelODE, y0: number[] | null,
-                     tStart: number, tEnd: number, control: any) {
+                     tStart: number, tEnd: number,
+                     control: Partial<DopriControlParam>) {
     // tslint:disable-next-line:only-arrow-functions
     const rhs = function(t: number, y: number[], dydt: number[]) {
         model.rhs(t, y, dydt);
@@ -80,7 +82,8 @@ function runModelODE(model: OdinModelODE, y0: number[] | null,
 }
 
 function runModelDDE(model: OdinModelDDE, y0: number[] | null,
-                     tStart: number, tEnd: number, control: any) {
+                     tStart: number, tEnd: number,
+                     control: Partial<DopriControlParam>) {
     // tslint:disable-next-line:only-arrow-functions
     const rhs = function(t: number, y: number[], dydt: number[],
                          solution: Solution) {

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -1,6 +1,5 @@
-import * as base from "./base";
 import type { OdinModel, OdinModelConstructable, Solution } from "./model";
-import {isODEModel, runModel} from "./model";
+import {base, isODEModel, runModel} from "./model";
 import type { UserType } from "./user";
 
 export class PkgWrapper {

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -1,3 +1,5 @@
+import type { DopriControlParam } from "dopri";
+
 import type { OdinModel, OdinModelConstructable, Solution } from "./model";
 import {base, isODEModel, runModel} from "./model";
 import type { UserType } from "./user";
@@ -42,7 +44,8 @@ export class PkgWrapper {
         this.model.setUser(pars, unusedUserAction);
     }
 
-    public run(t: number[], y0: number[] | null, control: any) {
+    public run(t: number[], y0: number[] | null,
+               control: Partial<DopriControlParam>) {
         const tStart = t[0];
         const tEnd = t[t.length - 1];
         const result = runModel(this.model, y0, tStart, tEnd, control);

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -1,7 +1,8 @@
 import type { DopriControlParam } from "dopri";
 
+import { base } from "./base";
 import type { OdinModel, OdinModelConstructable, Solution } from "./model";
-import {base, isODEModel, runModel} from "./model";
+import {isODEModel, runModel} from "./model";
 import type { UserType } from "./user";
 
 export class PkgWrapper {

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -1,6 +1,5 @@
-import * as base from "./base";
 import type { OdinModelConstructable, Solution } from "./model";
-import {runModel} from "./model";
+import {base, runModel} from "./model";
 import type { UserType } from "./user";
 
 // tslint:disable-next-line:variable-name

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -1,3 +1,5 @@
+import type { DopriControlParam } from "dopri";
+
 import type { OdinModelConstructable, Solution } from "./model";
 import {base, runModel} from "./model";
 import type { UserType } from "./user";
@@ -5,7 +7,7 @@ import type { UserType } from "./user";
 // tslint:disable-next-line:variable-name
 export function wodinRun(Model: OdinModelConstructable, pars: UserType,
                          tStart: number, tEnd: number,
-                         control: any) {
+                         control: Partial<DopriControlParam>) {
     const model = new Model(base, pars, "error");
     const y0 = null;
     const solution = runModel(model, y0, tStart, tEnd, control).solution;

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -1,7 +1,8 @@
 import type { DopriControlParam } from "dopri";
 
+import { base } from "./base";
 import type { OdinModelConstructable, Solution } from "./model";
-import {base, runModel} from "./model";
+import {runModel} from "./model";
 import type { UserType } from "./user";
 
 // tslint:disable-next-line:variable-name


### PR DESCRIPTION
This removes most of the `any` types, and uses types from dopri-js where these are available. There are still a couple of `any` types floating around, but one of those is subject to change and only used in the odin R code anyway