### PR TITLE
Add documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - run: npm install codecov -g
       - run: npm run-script test
       - run: npm run-script lint
+      - run: npm run-script docs
       - uses: codecov/codecov-action@v1
         with:
           files: coverage/*.json

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: docs
+
+on:
+  push:
+    branches: [main, master, mrc-3350]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - run: npm install
+      - run: npm run-script docs
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches: [main, master, mrc-3350]
+    branches: [main, master]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib
 .nyc_output
 coverage
 *.tgz
+docs

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-## wodin support
+## odin JavaScript support
 
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
-[![build status](https://github.com/mrc-ide/odin-js/workflows/ci/badge.svg)](https://github.com/mrc-ide/odin-js/actions)
-[![codecov.io](https://codecov.io/github/mrc-ide/odin-js/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/odin-js?branch=main)
+[![build-and-test](https://github.com/mrc-ide/odin-js/actions/workflows/ci.yml/badge.svg)](https://github.com/mrc-ide/odin-js/actions/workflows/ci.yml)
+[![codecov.io](https://codecov.io/github/mrc-ide/odin-js/coverage.svg?branch=main)](https://codecov.io/github/mrc-ide/odin-js?branch=main)
+
+Support for running [odin](https://mrc-ide.github.io/odin) models from JavaScript - this is used by odin itself for running models via [V8](https://github.com/jeroen/v8) and by [wodin](https://github.com/mrc-ide/wodin), the web interface.
 
 ## Licence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "ts-jest": "^28.0.0",
                 "ts-loader": "^9.3.0",
                 "tslint": "^5.20.1",
+                "typedoc": "^0.23.2",
                 "typescript": "^4.2.0",
                 "webpack": "^5.72.1",
                 "webpack-cli": "^4.9.2"
@@ -3510,6 +3511,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonc-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "dev": true
+        },
         "node_modules/kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3582,6 +3589,12 @@
                 "node": ">=10"
             }
         },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3610,6 +3623,18 @@
             "dev": true,
             "dependencies": {
                 "tmpl": "1.0.5"
+            }
+        },
+        "node_modules/marked": {
+            "version": "4.0.17",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+            "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
+            "dev": true,
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/merge-stream": {
@@ -4111,6 +4136,17 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/shiki": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+            "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+            "dev": true,
+            "dependencies": {
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "5.2.0"
             }
         },
         "node_modules/signal-exit": {
@@ -4677,6 +4713,48 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/typedoc": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.2.tgz",
+            "integrity": "sha512-THpC4vtb3wu1yck6YHzEc4ck6W4lScf8TD0Rg7XAetDih8BzP+ErYO0/6DtdzYcZyKkDwEoujkMeWW7CffCbrQ==",
+            "dev": true,
+            "dependencies": {
+                "lunr": "^2.3.9",
+                "marked": "^4.0.16",
+                "minimatch": "^5.1.0",
+                "shiki": "^0.10.1"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 14.14"
+            },
+            "peerDependencies": {
+                "typescript": "4.6.x || 4.7.x"
+            }
+        },
+        "node_modules/typedoc/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/typedoc/node_modules/minimatch": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+            "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/typescript": {
             "version": "4.7.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
@@ -4712,6 +4790,18 @@
             "engines": {
                 "node": ">=10.12.0"
             }
+        },
+        "node_modules/vscode-oniguruma": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+            "dev": true
+        },
+        "node_modules/vscode-textmate": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+            "dev": true
         },
         "node_modules/walker": {
             "version": "1.0.8",
@@ -7693,6 +7783,12 @@
             "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
             "dev": true
         },
+        "jsonc-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "dev": true
+        },
         "kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -7747,6 +7843,12 @@
                 "yallist": "^4.0.0"
             }
         },
+        "lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7770,6 +7872,12 @@
             "requires": {
                 "tmpl": "1.0.5"
             }
+        },
+        "marked": {
+            "version": "4.0.17",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+            "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
+            "dev": true
         },
         "merge-stream": {
             "version": "2.0.0",
@@ -8143,6 +8251,17 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
+        },
+        "shiki": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+            "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+            "dev": true,
+            "requires": {
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "5.2.0"
+            }
         },
         "signal-exit": {
             "version": "3.0.7",
@@ -8541,6 +8660,38 @@
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true
         },
+        "typedoc": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.2.tgz",
+            "integrity": "sha512-THpC4vtb3wu1yck6YHzEc4ck6W4lScf8TD0Rg7XAetDih8BzP+ErYO0/6DtdzYcZyKkDwEoujkMeWW7CffCbrQ==",
+            "dev": true,
+            "requires": {
+                "lunr": "^2.3.9",
+                "marked": "^4.0.16",
+                "minimatch": "^5.1.0",
+                "shiki": "^0.10.1"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+                    "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
+            }
+        },
         "typescript": {
             "version": "4.7.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
@@ -8566,6 +8717,18 @@
                 "@types/istanbul-lib-coverage": "^2.0.1",
                 "convert-source-map": "^1.6.0"
             }
+        },
+        "vscode-oniguruma": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+            "dev": true
+        },
+        "vscode-textmate": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+            "dev": true
         },
         "walker": {
             "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "scripts": {
         "build": "tsc",
         "webpack": "webpack",
+        "docs": "typedoc",
         "test": "jest -c jest.config.js",
         "lint": "tslint -c tslint.json 'src/**/*.ts'"
     },
@@ -29,6 +30,7 @@
         "ts-jest": "^28.0.0",
         "ts-loader": "^9.3.0",
         "tslint": "^5.20.1",
+        "typedoc": "^0.23.2",
         "typescript": "^4.2.0",
         "webpack": "^5.72.1",
         "webpack-cli": "^4.9.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odin",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,6 +1,6 @@
 import {delay} from "./delay";
-import * as maths from "./maths";
-import * as user from "./user";
+import {maths} from "./maths";
+import {user} from "./user";
 
 export const base = {delay, maths, user};
 export type BaseType = typeof base;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {BaseType, base} from "./base";
 export {
     OdinModelConstructable,
     OdinModel,
+    OdinModelBase,
     OdinModelODE,
     OdinModelDDE,
     Solution,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,11 @@
 export {wodinRun} from "./wodin";
 export {PkgWrapper} from "./pkg";
+
+export {
+    OdinModelConstructable,
+    OdinModel,
+    OdinModelODE,
+    OdinModelDDE,
+    Solution,
+} from "./model"
+export {InternalStorage, UserTensor, UserType, UserValue} from "./user"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export {wodinRun} from "./wodin";
 export {PkgWrapper} from "./pkg";
-
+export {BaseType, base} from "./base";
 export {
     OdinModelConstructable,
     OdinModel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,5 @@ export {
     OdinModelODE,
     OdinModelDDE,
     Solution,
-} from "./model"
-export {InternalStorage, UserTensor, UserType, UserValue} from "./user"
+} from "./model";
+export {InternalStorage, UserTensor, UserType, UserValue} from "./user";

--- a/src/maths.ts
+++ b/src/maths.ts
@@ -6,7 +6,7 @@ function roundHalfToEven(x: number) {
     }
 }
 
-/** Round a number. This function diffes from `Math.round` in two
+/** Round a number. This function differs from `Math.round` in two
  * respects - it can round to a number of digits with the optional
  * `digits` argument:
  *

--- a/src/maths.ts
+++ b/src/maths.ts
@@ -6,6 +6,29 @@ function roundHalfToEven(x: number) {
     }
 }
 
+/** Round a number. This function diffes from `Math.round` in two
+ * respects - it can round to a number of digits with the optional
+ * `digits` argument:
+ *
+ * ```typescript
+ * round2(1.2345, 2) // 1.23
+ * ```
+ *
+ * It follows the ["round half to
+ * even"](https://en.wikipedia.org/wiki/Rounding#Round_half_to_even)
+ * rounding rule, which avoids some biases
+ *
+ * ```typescript
+ * const x = [-2.5, -1.5, -0.5, 0.5, 1.5, 2.5];
+ * x.map(Math.round); // [ -2, -1, -0, 1, 2, 3 ]
+ * x.map(round2);     // [ -2  -2   0  0  2  2 ]
+ * ```
+ *
+ * @param x Number to be rounded
+ *
+ * @param digits Optional number of digits for `x` to be rounded to
+ * (default is zero)
+ */
 export function round2(x: number, digits?: number) {
     if (digits === undefined || digits === 0) {
         return roundHalfToEven(x);
@@ -15,7 +38,19 @@ export function round2(x: number, digits?: number) {
     }
 }
 
-// modulo that conforms to (approximately) the same behaviour as R
+/** A modulo (`%`) function that follows the same rules as R's `%%`
+ * for negative `x`
+ *
+ * ```typescript
+ * const x = [-3, -2, -1, 0, 1, 2, 3];
+ * x.map((el: number) => x % 3);      // [-0, -2, -1, 0, 1, 2, 0]
+ * x.map((el: number) => modr(x, 3)); // [-0,  1,  2, 0, 1, 2, 0]
+ * ```
+ *
+ * @param x Dividend
+ *
+ * @param y Divisor
+ */
 export function modr(x: number, y: number) {
     let tmp = x % y;
     if (tmp * y < 0) {
@@ -24,10 +59,22 @@ export function modr(x: number, y: number) {
     return tmp;
 }
 
+/** Integer division
+ * @param x Dividend
+ *
+ * @param y Divisor
+ */
 export function intdivr(x: number, y: number) {
     return Math.floor(x / y);
 }
 
+/** (Partial) sum over a single dimensional array
+ * @param x Array to be summed over
+ *
+ * @param from Index within `x` to start at
+ *
+ * @param to Index within `x` to finish at
+ */
 export function odinSum1(x: number[], from: number, to: number) {
     let tot = 0.0;
     for (let i = from; i < to; ++i) {
@@ -36,9 +83,25 @@ export function odinSum1(x: number[], from: number, to: number) {
     return tot;
 }
 
-// These are generated and are a bit fiddly to get right. I've copied
-// over the first 3 as they're generally enough for the tests and for
-// most models that anyone will actually write!
+// The remaining sums are generated and are a bit fiddly to get
+// right. I've copied over the first 3 as they're generally enough for
+// the tests and for most models that anyone will actually write!
+
+/** (Partial) sum over a matrix
+ *
+ * @param x Matrix to be summed over, stored as a flat array in
+ * column-major format
+ *
+ * @param iFrom Row index within `x` to start at
+ *
+ * @param iTo Row within `x` to finish at
+ *
+ * @param jFrom Column index within `x` to start at
+ *
+ * @param jTo Column within `x` to finish at
+ *
+ * @param dim1 Number of rows (length of dimension 1)
+ */
 export function odinSum2(x: number[], iFrom: number, iTo: number, jFrom: number, jTo: number, dim1: number) {
     let tot = 0.0;
     for (let j = jFrom; j < jTo; ++j) {
@@ -50,6 +113,26 @@ export function odinSum2(x: number[], iFrom: number, iTo: number, jFrom: number,
     return tot;
 }
 
+/** (Partial) sum over a 3d array (tensor)
+ *
+ * @param x Array to be summed over, stored as a flat array
+ *
+ * @param iFrom First dimension index within `x` to start at
+ *
+ * @param iTo First within `x` to finish at
+ *
+ * @param jFrom Second dimension index within `x` to start at
+ *
+ * @param jTo Second dimension within `x` to finish at
+ *
+ * @param kFrom Third dimension index within `x` to start at
+ *
+ * @param kTo Third dimension within `x` to finish at
+ *
+ * @param dim1 Length of dimension 1
+ *
+ * @param dim12 Length of the product of the first two dimensions
+ */
 export function odinSum3(x: number[], iFrom: number, iTo: number,
                          jFrom: number, jTo: number, kFrom: number,
                          kTo: number, dim1: number, dim12: number) {
@@ -65,3 +148,12 @@ export function odinSum3(x: number[], iFrom: number, iTo: number,
     }
     return tot;
 }
+
+export const maths = {
+    intdivr,
+    modr,
+    odinSum1,
+    odinSum2,
+    odinSum3,
+    round2,
+};

--- a/src/model.ts
+++ b/src/model.ts
@@ -60,7 +60,7 @@ export interface OdinModelODE {
      * variables.  Unlike {@link rhs}, this returns a vector rather
      * than writing in place. Not all models include an `output`
      * method - these models have no output.
-     * 
+     *
      * @param t The time to compute output at
      *
      * @param y The value of the variables
@@ -122,7 +122,7 @@ export interface OdinModelDDE {
      * variables.  Unlike {@link rhs}, this returns a vector rather
      * than writing in place. Not all models include an `output`
      * method - these models have no output.
-     * 
+     *
      * @param t The time to compute output at
      *
      * @param y The value of the variables
@@ -132,7 +132,7 @@ export interface OdinModelDDE {
      */
     output?(t: number, y: number[], solution: Solution): number[];
 
-    /** Return a vector of names of variables */    
+    /** Return a vector of names of variables */
     names(): string[];
 
     /**
@@ -160,8 +160,8 @@ export function isODEModel(model: OdinModel): model is OdinModelODE {
  * be an ordinary differential equation model ({@link OdinModelODE})
  * or a delay differential equation model ({@link
  * OdinModelDDE}). Later we will support discrete-time models here
- * too.  
-*/
+ * too.
+ */
 export type OdinModel = OdinModelODE | OdinModelDDE;
 
 export function runModel(model: OdinModel, y0: number[] | null,

--- a/src/model.ts
+++ b/src/model.ts
@@ -9,26 +9,141 @@ import {InternalStorage, UserType} from "./user";
 // could also use its types for the rhs and output members below.
 export type Solution = (t: number) => number[];
 
+/**
+ * Constructor for an {@link OdinModel}
+ *
+ * @param base TBD
+ *
+ * @param pars Parameters to pass to the model
+ *
+ * @param unusedUserAction String, describing the action to take if
+ * there are unknown values in `pars` - possible values are "error",
+ * "ignore", "warning" and "message"
+ */
 export type OdinModelConstructable =
     new(base: BaseType, pars: UserType, unknownAction: string) => OdinModel;
 
-interface OdinModelODE {
+/**
+ * The interface that odin ordinary differential equation (ODE) models
+ * will match, though they will be generated in plain JavaScript and
+ * not TypeScript.
+ */
+export interface OdinModelODE {
+    /**  Set parameters into an existing model.
+     *
+     * @param pars New parameters for the model. Values are are
+     * ommitted here but present in the model will be unchanged.
+     *
+     * @param unusedUserAction String, describing the action to take
+     * if there are unknown values in `pars` - possible values are
+     * "error", "ignore", "warning" and "message"
+     */
     setUser(pars: UserType, unknownAction: string): void;
+
+    /** Get initial conditions from the model
+     * @param t The time to compute initial conditions at
+     */
     initial(t: number): number[];
+
+    /** Compute the derivatives
+     *
+     * @param t The time to compute initial conditions at
+     *
+     * @param y The value of the variables
+     *
+     * @param dydt An array *that will be written into*, will hold
+     * derivatives on exit. Must be the same length as `y`
+     */
     rhs(t: number, y: number[], dydt: number[]): void;
+
+    /** Compute additional quantities that are derived from the
+     * variables.  Unlike {@link rhs}, this returns a vector rather
+     * than writing in place. Not all models include an `output`
+     * method - these models have no output.
+     * 
+     * @param t The time to compute output at
+     *
+     * @param y The value of the variables
+     */
     output?(t: number, y: number[]): number[];
+
+    /** Return a vector of names of variables */
     names(): string[];
+
+    /**
+     * Return the state of the internal storage - odin uses this for
+     * debugging and testing.
+     */
     getInternal(): InternalStorage;
+
+    /**
+     * Return metadata about the model - odin uses this internally.
+     */
     getMetadata(): any;
 }
 
-interface OdinModelDDE {
+/**
+ * The interface that odin delay differential equation (DDE) models
+ * will match, though they will be generated in plain JavaScript and
+ * not TypeScript.
+ */
+export interface OdinModelDDE {
+    /**  Set parameters into an existing model.
+     *
+     * @param pars New parameters for the model. Values are are
+     * ommitted here but present in the model will be unchanged.
+     *
+     * @param unusedUserAction String, describing the action to take
+     * if there are unknown values in `pars` - possible values are
+     * "error", "ignore", "warning" and "message"
+     */
     setUser(pars: UserType, unknownAction: string): void;
+
+    /** Get initial conditions from the model
+     * @param t The time to compute initial conditions at
+     */
     initial(t: number): number[];
+
+    /** Compute the derivatives
+     *
+     * @param t The time to compute initial conditions at
+     *
+     * @param y The value of the variables
+     *
+     * @param dydt An array *that will be written into*, will hold
+     * derivatives on exit. Must be the same length as `y`
+     *
+     * @param solution The interpolated solution, which is used to
+     * compute delayed versions of variables
+     */
     rhs(t: number, y: number[], dydt: number[], solution: Solution): void;
+
+    /** Compute additional quantities that are derived from the
+     * variables.  Unlike {@link rhs}, this returns a vector rather
+     * than writing in place. Not all models include an `output`
+     * method - these models have no output.
+     * 
+     * @param t The time to compute output at
+     *
+     * @param y The value of the variables
+     *
+     * @param solution The interpolated solution, which is used to
+     * compute delayed versions of variables
+     */
     output?(t: number, y: number[], solution: Solution): number[];
+
+    /** Return a vector of names of variables */    
     names(): string[];
+
+    /**
+     * Return the state of the internal storage - odin uses this for
+     * debugging and testing.
+     */
     getInternal(): InternalStorage;
+
+    /**
+     * Return metadata about the model - odin uses this internally.
+     */
     getMetadata(): any;
 }
 
@@ -40,6 +155,13 @@ export function isODEModel(model: OdinModel): model is OdinModelODE {
     return model.rhs.length === 3;
 }
 
+/**
+ * Union type representing supported odin models - currently this may
+ * be an ordinary differential equation model ({@link OdinModelODE})
+ * or a delay differential equation model ({@link
+ * OdinModelDDE}). Later we will support discrete-time models here
+ * too.  
+*/
 export type OdinModel = OdinModelODE | OdinModelDDE;
 
 export function runModel(model: OdinModel, y0: number[] | null,

--- a/src/model.ts
+++ b/src/model.ts
@@ -34,7 +34,7 @@ export interface OdinModelODE {
     /**  Set parameters into an existing model.
      *
      * @param pars New parameters for the model. Values are are
-     * ommitted here but present in the model will be unchanged.
+     * omitted here but present in the model will be unchanged.
      *
      * @param unusedUserAction String, describing the action to take
      * if there are unknown values in `pars` - possible values are
@@ -93,7 +93,7 @@ export interface OdinModelDDE {
     /**  Set parameters into an existing model.
      *
      * @param pars New parameters for the model. Values are are
-     * ommitted here but present in the model will be unchanged.
+     * omitted here but present in the model will be unchanged.
      *
      * @param unusedUserAction String, describing the action to take
      * if there are unknown values in `pars` - possible values are

--- a/src/model.ts
+++ b/src/model.ts
@@ -5,14 +5,16 @@ import {base, BaseType} from "./base";
 
 import {InternalStorage, UserType} from "./user";
 
-// Probably this is something that dopri should export for us, we
-// could also use its types for the rhs and output members below.
+/** Interpolated solution to the system of differential equations
+ *
+ *  @param t The time to look up the solution at
+ */
 export type Solution = (t: number) => number[];
 
 /**
  * Constructor for an {@link OdinModel}
  *
- * @param base TBD
+ * @param base The singleton object {@link base}
  *
  * @param pars Parameters to pass to the model
  *
@@ -21,7 +23,7 @@ export type Solution = (t: number) => number[];
  * "ignore", "warning" and "message"
  */
 export type OdinModelConstructable =
-    new(base: BaseType, pars: UserType, unknownAction: string) => OdinModel;
+    new(base: BaseType, pars: UserType, unusedUserAction: string) => OdinModel;
 
 /**
  * The interface that odin ordinary differential equation (ODE) models
@@ -38,7 +40,7 @@ export interface OdinModelODE {
      * if there are unknown values in `pars` - possible values are
      * "error", "ignore", "warning" and "message"
      */
-    setUser(pars: UserType, unknownAction: string): void;
+    setUser(pars: UserType, unusedUserAction: string): void;
 
     /** Get initial conditions from the model
      * @param t The time to compute initial conditions at
@@ -97,7 +99,7 @@ export interface OdinModelDDE {
      * if there are unknown values in `pars` - possible values are
      * "error", "ignore", "warning" and "message"
      */
-    setUser(pars: UserType, unknownAction: string): void;
+    setUser(pars: UserType, unusedUserAction: string): void;
 
     /** Get initial conditions from the model
      * @param t The time to compute initial conditions at

--- a/src/model.ts
+++ b/src/model.ts
@@ -25,12 +25,8 @@ export type Solution = (t: number) => number[];
 export type OdinModelConstructable =
     new(base: BaseType, pars: UserType, unusedUserAction: string) => OdinModel;
 
-/**
- * The interface that odin ordinary differential equation (ODE) models
- * will match, though they will be generated in plain JavaScript and
- * not TypeScript.
- */
-export interface OdinModelODE {
+/** Common interface for all odin models */
+export interface OdinModelBase {
     /**  Set parameters into an existing model.
      *
      * @param pars New parameters for the model. Values are are
@@ -47,6 +43,27 @@ export interface OdinModelODE {
      */
     initial(t: number): number[];
 
+    /** Return a vector of names of variables */
+    names(): string[];
+
+    /**
+     * Return the state of the internal storage - odin uses this for
+     * debugging and testing.
+     */
+    getInternal(): InternalStorage;
+
+    /**
+     * Return metadata about the model - odin uses this internally.
+     */
+    getMetadata(): any;
+}
+
+/**
+ * The interface that odin ordinary differential equation (ODE) models
+ * will match, though they will be generated in plain JavaScript and
+ * not TypeScript.
+ */
+export interface OdinModelODE extends OdinModelBase {
     /** Compute the derivatives
      *
      * @param t The time to compute initial conditions at
@@ -68,20 +85,6 @@ export interface OdinModelODE {
      * @param y The value of the variables
      */
     output?(t: number, y: number[]): number[];
-
-    /** Return a vector of names of variables */
-    names(): string[];
-
-    /**
-     * Return the state of the internal storage - odin uses this for
-     * debugging and testing.
-     */
-    getInternal(): InternalStorage;
-
-    /**
-     * Return metadata about the model - odin uses this internally.
-     */
-    getMetadata(): any;
 }
 
 /**
@@ -89,23 +92,7 @@ export interface OdinModelODE {
  * will match, though they will be generated in plain JavaScript and
  * not TypeScript.
  */
-export interface OdinModelDDE {
-    /**  Set parameters into an existing model.
-     *
-     * @param pars New parameters for the model. Values are are
-     * omitted here but present in the model will be unchanged.
-     *
-     * @param unusedUserAction String, describing the action to take
-     * if there are unknown values in `pars` - possible values are
-     * "error", "ignore", "warning" and "message"
-     */
-    setUser(pars: UserType, unusedUserAction: string): void;
-
-    /** Get initial conditions from the model
-     * @param t The time to compute initial conditions at
-     */
-    initial(t: number): number[];
-
+export interface OdinModelDDE extends OdinModelBase {
     /** Compute the derivatives
      *
      * @param t The time to compute initial conditions at
@@ -133,20 +120,6 @@ export interface OdinModelDDE {
      * compute delayed versions of variables
      */
     output?(t: number, y: number[], solution: Solution): number[];
-
-    /** Return a vector of names of variables */
-    names(): string[];
-
-    /**
-     * Return the state of the internal storage - odin uses this for
-     * debugging and testing.
-     */
-    getInternal(): InternalStorage;
-
-    /**
-     * Return metadata about the model - odin uses this internally.
-     */
-    getMetadata(): any;
 }
 
 export function isDDEModel(model: OdinModel): model is OdinModelDDE {

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -5,18 +5,43 @@ import type { OdinModel, OdinModelConstructable, Solution } from "./model";
 import {isODEModel, runModel} from "./model";
 import type { UserType } from "./user";
 
+/**
+ * Wrapper class around an {@link OdinModel} designed to be driven
+ * from the R package (https://github.com/mrc-ide/odin)
+ */
 export class PkgWrapper {
     private model: OdinModel;
 
+    /**
+     * @param Model The model to wrap
+     *
+     * @param pars Parameters to set into the model on construction
+     *
+     * @param unusedUserAction String, describing the action to take
+     * if there are unknown values in `pars` - possible values are
+     * "error", "ignore", "warning" and "message"
+     */
     // tslint:disable-next-line:variable-name
     constructor(Model: OdinModelConstructable, pars: UserType, unusedUserAction: string) {
         this.model = new Model(base, pars, unusedUserAction);
     }
 
+    /**
+     * Compute initial conditions of the model
+     *
+     * @param t The time to compute initial conditions at
+     */
     public initial(t: number) {
         return this.model.initial(t);
     }
 
+    /**
+     * Compute derivatives of the model
+     *
+     * @param t The time to compute the derivatve at
+     *
+     * @param y The value of the variables
+     */
     public rhs(t: number, y: number[]) {
         const state = new Array(y.length).fill(0);
         let output = null;
@@ -30,28 +55,73 @@ export class PkgWrapper {
         } else {
             throw Error("Can't use rhs() with delay models");
         }
-        return {output, state};
+        return {
+            /** Output, if the model has an `output` method, `null` otherwise */
+            output,
+            /** Derivatives of the state variables */
+            state,
+        };
     }
 
+    /**
+     * Return metadata about the model - odin uses this internally.
+     */
     public getMetadata() {
         return this.model.getMetadata();
     }
 
+    /**
+     * Return the state of the internal storage - odin uses this for
+     * debugging and testing.
+     */
     public getInternal() {
         return this.model.getInternal();
     }
 
+    /**
+     * Change parameters in a model after it has been initialised.
+     *
+     * @param pars Parameters to set. Values that are omitted are not
+     * replaced by their defaults.
+     *
+     * @param unusedUserAction Action to take if unknown values are
+     * found in `pars`, see {@link PkgWrapper.constructor}
+     */
     public setUser(pars: UserType, unusedUserAction: string) {
         this.model.setUser(pars, unusedUserAction);
     }
 
+    /**
+     * Run the model, returning output at particular points in
+     * time. Note that this is quite a different interface to that
+     * used in {@link wodinRun} in order to match the interface
+     * expected by odin, but also due to limitations of what can be
+     * carried across the R/JS boundary.
+     *
+     * @param t A vector of times to integrate over. Must be in
+     * increasing order, and at least two values given. The first time
+     * is the time that the integration starts from.
+     *
+     * @param y0 Initial conditions, or `null` to use values from
+     * {@link PkgWrapper.initial}
+     *
+     * @param control Control parameters, passed through to the solver, see
+     * [`dopri.DopriControlParam`](https://mrc-ide.github.io/dopri-js/interfaces/DopriControlParam.html)
+     */
     public run(t: number[], y0: number[] | null,
                control: Partial<DopriControlParam>) {
         const tStart = t[0];
         const tEnd = t[t.length - 1];
         const result = runModel(this.model, y0, tStart, tEnd, control);
-        return {names: this.model.names(),
-                statistics: result.statistics,
-                y: result.solution(t)};
+        return {
+            /** Names of all variables (and outputs) in the system */
+            names: this.model.names(),
+            /** Statistics from the solver about work done */
+            statistics: result.statistics,
+            /** Array-of-arrays with the result `y[i][j]` is the `j`th
+             * output at the `i`th time
+             */
+            y: result.solution(t),
+        };
     }
 }

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -7,7 +7,7 @@ import type { UserType } from "./user";
 
 /**
  * Wrapper class around an {@link OdinModel} designed to be driven
- * from the R package (https://github.com/mrc-ide/odin)
+ * from the [R package odin](https://github.com/mrc-ide/odin)
  */
 export class PkgWrapper {
     private model: OdinModel;
@@ -21,7 +21,6 @@ export class PkgWrapper {
      * if there are unknown values in `pars` - possible values are
      * "error", "ignore", "warning" and "message"
      */
-    // tslint:disable-next-line:variable-name
     constructor(Model: OdinModelConstructable, pars: UserType, unusedUserAction: string) {
         this.model = new Model(base, pars, unusedUserAction);
     }

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,9 +1,47 @@
+/** Store vectors and multidimensional arrays. Rather than store a
+ *  matrix of data like
+ * ```typescript
+ * [[ 0,  1,  2,  3],
+ *  [ 4,  5,  6,  7],
+ *  [ 8,  9, 10, 11]]
+ * ```
+ * we store this as
+ *
+ * ```typescript
+ * {
+ *     data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+ *     dim: [4, 3]
+ * }
+ * ```
+ *
+ * This is modelled on the way that odin stores matrices. In odin
+ * syntax, the element `m[2, 3]` has value 9.
+ */
 export interface UserTensor {
+    /** The data, as a single array */
     data: number[];
+    /** The dimensions as a relatively short array (length 1 to 3 for
+     *  odin-js curently, limited by support in sums)
+     */
     dim: number[];
 }
+
+/**
+ * Valid values that may be passed in within a {@link UserType} map
+ */
 export type UserValue = number | number[] | UserTensor;
+
+/**
+ * A key-value map of user-provided parameters
+ */
 export type UserType = Map<string, UserValue>;
+
+/**
+ * The data type corresponding to odin's internal data structures - a
+ * key-value mapping of name to numbers or vectors. Returned by {@link
+ * OdinModelODE.getInternal | OdinModelODE.getInternal} and not
+ * generally meant for end-user consumption except for in debugging.
+ */
 export type InternalStorage = Record<string, number | number[]>;
 
 export function checkUser(user: UserType, allowed: string[],

--- a/src/user.ts
+++ b/src/user.ts
@@ -98,12 +98,12 @@ export function checkUser(pars: UserType, allowed: string[],
  * parameter is required
  *
  * @param min The minimum allowed value for the parameter; use
- * `-Infinity` there is no minimum
+ * `-Infinity` if there is no minimum
  *
  * @param max The maximum allowed value for the parameter; use
- * `Infinity` there is no maximum
+ * `Infinity` if there is no maximum
  *
- * @param isInteger Check that the provided value is a parameter
+ * @param isInteger Check that the provided value is an integer```
  */
 export function setUserScalar(pars: UserType, name: string,
                               internal: InternalStorage,
@@ -148,7 +148,7 @@ export function setUserScalar(pars: UserType, name: string,
  * @param max The maximum allowed value for the parameter; use
  * `Infinity` there is no maximum
  *
- * @param isInteger Check that the provided value is a parameter
+ * @param isInteger Check that the provided value is an integer
  */
 export function setUserArrayFixed(pars: UserType, name: string,
                                   internal: InternalStorage,

--- a/src/user.ts
+++ b/src/user.ts
@@ -103,7 +103,7 @@ export function checkUser(pars: UserType, allowed: string[],
  * @param max The maximum allowed value for the parameter; use
  * `Infinity` if there is no maximum
  *
- * @param isInteger Check that the provided value is an integer```
+ * @param isInteger Check that the provided value is an integer
  */
 export function setUserScalar(pars: UserType, name: string,
                               internal: InternalStorage,

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -5,7 +5,6 @@ import type { OdinModelConstructable, Solution } from "./model";
 import {runModel} from "./model";
 import type { UserType } from "./user";
 
-// tslint:disable-next-line:variable-name
 export function wodinRun(Model: OdinModelConstructable, pars: UserType,
                          tStart: number, tEnd: number,
                          control: Partial<DopriControlParam>) {

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -5,6 +5,20 @@ import type { OdinModelConstructable, Solution } from "./model";
 import {runModel} from "./model";
 import type { UserType } from "./user";
 
+/** The "run" method for wodin; this runs the model and returns a
+ * closure that will provide data in a useful format to provide to
+ * plotly.
+ *
+ * @param Model The model constructor
+ *
+ * @param pars Parameters to set into the model on construction
+ *
+ * @param tStart Start of the integration (often 0)
+ *
+ * @param tEnd End of the integration (must be greater than `tStart`)
+ *
+ * @param control Optional control parameters to tune the integration
+ */
 export function wodinRun(Model: OdinModelConstructable, pars: UserType,
                          tStart: number, tEnd: number,
                          control: Partial<DopriControlParam>) {
@@ -12,11 +26,32 @@ export function wodinRun(Model: OdinModelConstructable, pars: UserType,
     const y0 = null;
     const solution = runModel(model, y0, tStart, tEnd, control).solution;
     const names = model.names();
+    /**
+     * @param t0 Start time to return the solution (cannot be less
+     * than `tStart` - we will increase it to `tStart` in that case)
+     *
+     * @param t1 End time to return the solution (cannot be more than
+     * `tEnd` - we will reduce it to `tEnd` in that case)
+     *
+     * @param nPoints Number of points to return - must be at least
+     * two, and points will be evenly spaced between `t0` and `t1`
+     *
+     * @return Returns an array where each element represents a
+     * series. Each element is an object with fields `name` (the name
+     * of the series), `x` (the time values - these will be the same
+     * for every series) and `y` (the series value at each time, the
+     * same length as `x`).
+     */
     return (t0: number, t1: number, nPoints: number) => {
-        const t = grid(Math.max(0, t0), Math.min(t1, tEnd), nPoints);
+        const t = grid(Math.max(t0, tStart), Math.min(t1, tEnd), nPoints);
         const y = solution(t);
+        // Unfortunately adding typedoc annotations here does not
+        // propagate them up above.
         return y[0].map((_: any, i: number) => ({
-            name: names[i], x: t, y: y.map((row: number[]) => row[i])}));
+            name: names[i],
+            x: t,
+            y: y.map((row: number[]) => row[i]),
+        }));
     };
 }
 

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
     "jsRules": {},
     "rules": {
         "interface-name": [true, "never-prefix"],
-        "variable-name": [true, "allow-leading-underscore"],
+        "variable-name": [true, "allow-leading-underscore", "allow-pascal-case"],
         "no-console": false
     },
     "rulesDirectory": []

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": ["src/index.ts"],
+    "out": "docs",
+    "excludePrivate": true,
+    "excludeInternal": true,
+    "excludeNotDocumented": false
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,6 +2,7 @@
     "entryPoints": ["src/index.ts"],
     "out": "docs",
     "excludePrivate": true,
+    "excludeProtected": true,
     "excludeInternal": true,
     "excludeNotDocumented": false
 }


### PR DESCRIPTION
~Merge after #6, as this PR builds on that one.~

I've had to slightly rejig how the `base` object was created because otherwise there were stray `__module` bits within it. This way seems reasonable though?

There are more exports than before - that's because typedoc tells you when you've referenced something that is not exported - most of these are just types.

Otherwise this PR should be minor formatting changes plus addition of doc comments

Docs online here: https://mrc-ide.github.io/odin-js/
