### PR TITLE
Implement fitting in odin-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.2",
             "license": "MIT",
             "dependencies": {
-                "dfoptim": "^0.0.4",
+                "dfoptim": "^0.0.5",
                 "dopri": "^0.0.12"
             },
             "devDependencies": {
@@ -19,6 +19,22 @@
                 "ts-loader": "^9.3.0",
                 "tslint": "^5.20.1",
                 "typedoc": "^0.23.2",
+                "typescript": "^4.2.0",
+                "webpack": "^5.72.1",
+                "webpack-cli": "^4.9.2"
+            }
+        },
+        "../dfoptim": {
+            "version": "0.0.5",
+            "extraneous": true,
+            "license": "MIT",
+            "devDependencies": {
+                "@types/jest": "^27.5.1",
+                "jest": "^28.0.0",
+                "ts-jest": "^28.0.0",
+                "ts-loader": "^9.3.0",
+                "tslint": "^5.20.1",
+                "typedoc": "^0.23.1",
                 "typescript": "^4.2.0",
                 "webpack": "^5.72.1",
                 "webpack-cli": "^4.9.2"
@@ -1874,9 +1890,9 @@
             }
         },
         "node_modules/dfoptim": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/dfoptim/-/dfoptim-0.0.4.tgz",
-            "integrity": "sha512-VT5aRC2/+pirdLqqpZ7ICBm3tL9U5+S0ipmSOceiyhj26wolSGSMYmDPumt5Z8Uf1+zsjuOj7849svAXPRJc/w=="
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/dfoptim/-/dfoptim-0.0.5.tgz",
+            "integrity": "sha512-9HklLgyW+Yv+jr7zo+S06Qjch1FEwnJrUFyKRVpCbkoomtyi+nKuoQJMvSEO3cYQHY/fg49Ri5uBoT/oaKHBBQ=="
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -6547,9 +6563,9 @@
             "dev": true
         },
         "dfoptim": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/dfoptim/-/dfoptim-0.0.4.tgz",
-            "integrity": "sha512-VT5aRC2/+pirdLqqpZ7ICBm3tL9U5+S0ipmSOceiyhj26wolSGSMYmDPumt5Z8Uf1+zsjuOj7849svAXPRJc/w=="
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/dfoptim/-/dfoptim-0.0.5.tgz",
+            "integrity": "sha512-9HklLgyW+Yv+jr7zo+S06Qjch1FEwnJrUFyKRVpCbkoomtyi+nKuoQJMvSEO3cYQHY/fg49Ri5uBoT/oaKHBBQ=="
         },
         "diff": {
             "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "@reside-ic/odin",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/odin",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "MIT",
             "dependencies": {
+                "dfoptim": "^0.0.4",
                 "dopri": "^0.0.12"
             },
             "devDependencies": {
@@ -1871,6 +1872,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/dfoptim": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/dfoptim/-/dfoptim-0.0.4.tgz",
+            "integrity": "sha512-VT5aRC2/+pirdLqqpZ7ICBm3tL9U5+S0ipmSOceiyhj26wolSGSMYmDPumt5Z8Uf1+zsjuOj7849svAXPRJc/w=="
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -6539,6 +6545,11 @@
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true
+        },
+        "dfoptim": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/dfoptim/-/dfoptim-0.0.4.tgz",
+            "integrity": "sha512-VT5aRC2/+pirdLqqpZ7ICBm3tL9U5+S0ipmSOceiyhj26wolSGSMYmDPumt5Z8Uf1+zsjuOj7849svAXPRJc/w=="
         },
         "diff": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odin",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
+        "dfoptim": "^0.0.4",
         "dopri": "^0.0.12"
     }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "dfoptim": "^0.0.4",
+        "dfoptim": "^0.0.5",
         "dopri": "^0.0.12"
     }
 }

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -1,6 +1,6 @@
 import {Simplex} from "dfoptim";
 
-import * as base from "./base";
+import { base } from "./base";
 import type { OdinModelConstructable, Solution } from "./model";
 import {interpolatedSolution, partialInterpolatedSolution, runModel} from "./model";
 import type {UserType} from "./user";

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -1,28 +1,32 @@
-import {Simplex} from "dfoptim";
-
 import { base } from "./base";
 import type { OdinModelConstructable, Solution } from "./model";
 import {interpolatedSolution, partialInterpolatedSolution, runModel} from "./model";
 import type {UserType} from "./user";
 
+/** Interface for data to fit an odin model to; every data set has two
+ *  series, even if they are derived from some larger data set.
+ */
 export interface FitData {
+    /** Array of time values; must be increasing */
     time: number[];
+    /** Observed data to fit to; must be the same length as `time` */
     value: number[];
 }
 
+/** Interface to control parameters of a fit. A model will have some
+ *  number of parameters but only some change. We also need to provide
+ *  starting points for the fit.
+ */
 export interface FitPars {
+    /** Base parameters; used as starting points for those that change
+     * (within `vary`) and fixed values for those that don't change
+     */
     base: UserType;
+    /** Array of names of parameters that should be optimised during
+     * the fitting process. All values in `vary` must be present as
+     * keys in `base`.
+     */
     vary: string[];
-}
-
-export function startFit(Model: OdinModelConstructable, data: FitData,
-                         pars: FitPars, modelledSeries: string,
-                         controlODE: any, controlFit: any) {
-    const target = fitTarget(Model, data, pars, modelledSeries, controlODE);
-    // TODO: require that we have starting points here (i.e., that
-    // everything variable is in fact a number)
-    const start = pars.vary.map((nm: string) => pars.base.get(nm) as number);
-    return new Simplex(target, start, controlFit);
 }
 
 export function fitTarget(Model: OdinModelConstructable,
@@ -31,32 +35,32 @@ export function fitTarget(Model: OdinModelConstructable,
                           control: any) {
     const tStart = data.time[0];
     const tEnd = data.time[data.time.length - 1];
-    // TODO: it would be preferable if this error handling moved into
-    // dfoptim, as it will be fairly common; could make it an option
-    // for the control, which would be much nicer and easier to test.
     return (theta: number[]) => {
         const p = updatePars(pars, theta);
         const model = new Model(base, p, "error");
         const y0 = null;
-        const solution =
-            runModel(model, y0, tStart, tEnd, control).solution;
-
+        const solution = runModel(model, y0, tStart, tEnd, control).solution;
         const names = model.names();
         const idxModel = names.indexOf(modelledSeries);
         const yModel = solution(data.time).map((y) => y[idxModel]);
-        const value = sumOfSquares(data.value, yModel);
 
-        // We return a solution-type function just for the modelled
-        // series as that's probably what the caller will
-        // want. However, the full solution will be available too,
-        // alongside the names.
-        const solutionFit = partialInterpolatedSolution(
-            solution, modelledSeries, idxModel, tStart, tEnd);
-        const solutionAll = interpolatedSolution(
-            solution, names, tStart, tEnd);
-
-        return { data: {names, pars: p, solutionAll, solutionFit},
-                 value };
+        // Unfortunately, TypeDoc does not copy all doc comments here
+        // over, so I've not documented them here.
+        return {
+            /** Additional data alongside the goodness of fit, see above */
+            data: {
+                names,
+                pars: p,
+                solutionAll: interpolatedSolution(
+                    solution, names, tStart, tEnd),
+                solutionFit: partialInterpolatedSolution(
+                    solution, modelledSeries, idxModel, tStart, tEnd),
+            },
+            /** Goodness of fit, the sum-of-squared differences
+             * between the observed data and the modelled series
+             */
+            value: sumOfSquares(data.value, yModel),
+        };
     };
 }
 

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -44,8 +44,6 @@ export function fitTarget(Model: OdinModelConstructable,
         const idxModel = names.indexOf(modelledSeries);
         const yModel = solution(data.time).map((y) => y[idxModel]);
 
-        // Unfortunately, TypeDoc does not copy all doc comments here
-        // over, so I've not documented them here.
         return {
             /** Additional data alongside the goodness of fit, see above */
             data: {

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -1,0 +1,77 @@
+import {Simplex} from "dfoptim";
+
+import * as base from "./base";
+import type { OdinModelConstructable, Solution } from "./model";
+import {interpolatedSolution, partialInterpolatedSolution, runModel} from "./model";
+import type {UserType} from "./user";
+
+export interface FitData {
+    time: number[];
+    value: number[];
+}
+
+export interface FitPars {
+    base: UserType;
+    vary: string[];
+}
+
+export function startFit(Model: OdinModelConstructable, data: FitData,
+                         pars: FitPars, modelledSeries: string,
+                         controlODE: any, controlFit: any) {
+    const target = fitTarget(Model, data, pars, modelledSeries, controlODE);
+    // TODO: require that we have starting points here (i.e., that
+    // everything variable is in fact a number)
+    const start = pars.vary.map((nm: string) => pars.base.get(nm) as number);
+    return new Simplex(target, start, controlFit);
+}
+
+export function fitTarget(Model: OdinModelConstructable,
+                          data: FitData, pars: FitPars,
+                          modelledSeries: string,
+                          control: any) {
+    const tStart = data.time[0];
+    const tEnd = data.time[data.time.length - 1];
+    // TODO: it would be preferable if this error handling moved into
+    // dfoptim, as it will be fairly common; could make it an option
+    // for the control, which would be much nicer and easier to test.
+    return (theta: number[]) => {
+        const p = updatePars(pars, theta);
+        const model = new Model(base, p, "error");
+        const y0 = null;
+        const solution =
+            runModel(model, y0, tStart, tEnd, control).solution;
+
+        const names = model.names();
+        const idxModel = names.indexOf(modelledSeries);
+        const yModel = solution(data.time).map((y) => y[idxModel]);
+        const value = sumOfSquares(data.value, yModel);
+
+        // We return a solution-type function just for the modelled
+        // series as that's probably what the caller will
+        // want. However, the full solution will be available too,
+        // alongside the names.
+        const solutionFit = partialInterpolatedSolution(
+            solution, modelledSeries, idxModel, tStart, tEnd);
+        const solutionAll = interpolatedSolution(
+            solution, names, tStart, tEnd);
+
+        return { data: {names, pars: p, solutionAll, solutionFit},
+                 value };
+    };
+}
+
+export function updatePars(pars: FitPars, theta: number[]) {
+    const ret = new Map(pars.base);
+    for (let i = 0; i < pars.vary.length; ++i) {
+        ret.set(pars.vary[i], theta[i]);
+    }
+    return ret;
+}
+
+export function sumOfSquares(x: number[], y: number[]) {
+    let tot = 0;
+    for (let i = 0; i < x.length; ++i) {
+        tot += (x[i] - y[i]) ** 2;
+    }
+    return tot;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-export {wodinRun} from "./wodin";
+export {wodinFit, wodinRun} from "./wodin";
 export {PkgWrapper} from "./pkg";
 export {BaseType, base} from "./base";
+export {FitData, FitPars} from "./fit";
 export {
     OdinModelConstructable,
     OdinModel,

--- a/src/model.ts
+++ b/src/model.ts
@@ -212,23 +212,35 @@ function runModelDDE(model: OdinModelDDE, y0: number[] | null,
 }
 
 /**
- * @param t0 Start time to return the solution (cannot be less
- * than `tStart` - we will increase it to `tStart` in that case)
+ * Conversion function for Dopri output into plotly input, allowing
+ * efficient re-interpolation of subsets of the graph.
  *
- * @param t1 End time to return the solution (cannot be more than
- * `tEnd` - we will reduce it to `tEnd` in that case)
+ * @param solution The solution as returned from the solver
  *
- * @param nPoints Number of points to return - must be at least
- * two, and points will be evenly spaced between `t0` and `t1`
+ * @param names Vector of names for the traces
  *
- * @return Returns an array where each element represents a
- * series. Each element is an object with fields `name` (the name
- * of the series), `x` (the time values - these will be the same
- * for every series) and `y` (the series value at each time, the
- * same length as `x`).
+ * @param tStart Starting time for the integration
+ *
+ * @param tEnd End time for the integration
  */
 export function interpolatedSolution(solution: FullSolution, names: string[],
                                      tStart: number, tEnd: number) {
+    /**
+     * @param t0 Start time to return the solution (cannot be less
+     * than `tStart` - we will increase it to `tStart` in that case)
+     *
+     * @param t1 End time to return the solution (cannot be more than
+     * `tEnd` - we will reduce it to `tEnd` in that case)
+     *
+     * @param nPoints Number of points to return - must be at least
+     * two, and points will be evenly spaced between `t0` and `t1`
+     *
+     * @return Returns an array where each element represents a
+     * series. Each element is an object with fields `name` (the name
+     * of the series), `x` (the time values - these will be the same
+     * for every series) and `y` (the series value at each time, the
+     * same length as `x`).
+     */
     return (t0: number, t1: number, nPoints: number) => {
         const t = grid(Math.max(tStart, t0), Math.min(tEnd, t1), nPoints);
         const y = solution(t);
@@ -243,12 +255,46 @@ export function interpolatedSolution(solution: FullSolution, names: string[],
     };
 }
 
+/**
+ * Conversion function for Dopri output into plotly input for a single
+ * series, allowing efficient re-interpolation of subsets of the
+ * graph. This is a single-trace version of {@link
+ * fullInterpolatedSolution} intended for use with {@link wodinFit}
+ * (via {@link fitTarget}).
+ *
+ * @param solution The solution as returned from the solver
+ *
+ * @param name Name for the returned trace
+ *
+ * @param index The numeric index of the required trace within the
+ * solution
+ *
+ * @param tStart Starting time for the integration
+ *
+ * @param tEnd End time for the integration
+ */
 export function partialInterpolatedSolution(solution: FullSolution,
                                             name: string, index: number,
                                             tStart: number, tEnd: number) {
+    /**
+     * @param t0 Start time to return the solution (cannot be less
+     * than `tStart` - we will increase it to `tStart` in that case)
+     *
+     * @param t1 End time to return the solution (cannot be more than
+     * `tEnd` - we will reduce it to `tEnd` in that case)
+     *
+     * @param nPoints Number of points to return - must be at least
+     * two, and points will be evenly spaced between `t0` and `t1`
+     *
+     * @return Returns an object with fields `name` (the name of the
+     * series), `x` (the time values) and `y` (the series value at
+     * each time, the same length as `x`).
+     */
     return (t0: number, t1: number, nPoints: number) => {
         const t = grid(Math.max(tStart, t0), Math.min(tEnd, t1), nPoints);
+        // TODO: we should support this in dopri directly
         const y = solution(t).map((yt) => yt[index]);
+        // Unfortunately typedoc comments not picked up properly here
         return {name, x: t, y};
     };
 }

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -1,12 +1,11 @@
+import { Simplex, SimplexControlParam } from "dfoptim";
 import type { DopriControlParam } from "dopri";
 
 import { base } from "./base";
-import { startFit } from "./fit";
+import { FitData, FitPars, fitTarget } from "./fit";
 import type { OdinModelConstructable, Solution } from "./model";
 import { interpolatedSolution, runModel } from "./model";
 import type { UserType } from "./user";
-
-export {startFit as wodinFit} from "./fit";
 
 /** The "run" method for wodin; this runs the model and returns a
  * closure that will provide data in a useful format to provide to
@@ -30,4 +29,51 @@ export function wodinRun(Model: OdinModelConstructable, pars: UserType,
     const solution = runModel(model, y0, tStart, tEnd, control).solution;
     const names = model.names();
     return interpolatedSolution(solution, names, tStart, tEnd);
+}
+
+/** Begin a fit. This will evaluate the model `pars.vary.length + 1`
+ * times, and then return a
+ * [`dfoptim.Simplex`](https://reside-ic.github.io/dfoptim/classes/Simplex.html)
+ * object. You can then call `.run()` to fit the model in one go
+ * (could block for a long time) or repeatedly call `.step()` until it
+ * returns `true` when it has converged.
+ *
+ * The `data` field of the returned value, both during a run via
+ * `.result()` and on convergence (perhaps via `.run()`) will have
+ * interpolated solutions available via an object containing:
+ *
+ * * `names`: the names of all traces returned by the model
+ * * `pars`: The full model parameters, as a Map (i.e., suitable to
+ *   pass back into an {@link OdinModelConstructable} object or {@link
+ *   wodinRun})
+ * * `solutionAll`: The solution of all series; an interpolating
+ *   function as as would be returned by {@link wodinRun}
+ * * `solutionFit`: The solution to a just the modelled series being
+ *    fit, as a single trace
+ *
+ * @param Model The model constructor
+ *
+ * @param data The data to fit to; there will be one time and one data
+ * series within this
+ *
+ * @param pars Information about the parameters; which are to be
+ * varied, which to be fixed, and their starting values
+ *
+ * @param modelledSeries Name of the series of data produced by the
+ * model that should be compared with the data.
+ *
+ * @param controlODE Control parameters to tune the integration
+ *
+ * @param controlFit Control parameters to tune the optimisation
+ *
+ */
+export function wodinFit(Model: OdinModelConstructable, data: FitData,
+                         pars: FitPars, modelledSeries: string,
+                         controlODE: Partial<DopriControlParam>,
+                         controlFit: Partial<SimplexControlParam>) {
+    const target = fitTarget(Model, data, pars, modelledSeries, controlODE);
+    // TODO: require that we have starting points here (i.e., that
+    // everything variable is in fact a number)
+    const start = pars.vary.map((nm: string) => pars.base.get(nm) as number);
+    return new Simplex(target, start, controlFit);
 }

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -1,9 +1,12 @@
 import type { DopriControlParam } from "dopri";
 
 import { base } from "./base";
+import { startFit } from "./fit";
 import type { OdinModelConstructable, Solution } from "./model";
-import {runModel} from "./model";
+import { interpolatedSolution, runModel } from "./model";
 import type { UserType } from "./user";
+
+export {startFit as wodinFit} from "./fit";
 
 /** The "run" method for wodin; this runs the model and returns a
  * closure that will provide data in a useful format to provide to
@@ -26,41 +29,5 @@ export function wodinRun(Model: OdinModelConstructable, pars: UserType,
     const y0 = null;
     const solution = runModel(model, y0, tStart, tEnd, control).solution;
     const names = model.names();
-    /**
-     * @param t0 Start time to return the solution (cannot be less
-     * than `tStart` - we will increase it to `tStart` in that case)
-     *
-     * @param t1 End time to return the solution (cannot be more than
-     * `tEnd` - we will reduce it to `tEnd` in that case)
-     *
-     * @param nPoints Number of points to return - must be at least
-     * two, and points will be evenly spaced between `t0` and `t1`
-     *
-     * @return Returns an array where each element represents a
-     * series. Each element is an object with fields `name` (the name
-     * of the series), `x` (the time values - these will be the same
-     * for every series) and `y` (the series value at each time, the
-     * same length as `x`).
-     */
-    return (t0: number, t1: number, nPoints: number) => {
-        const t = grid(Math.max(t0, tStart), Math.min(t1, tEnd), nPoints);
-        const y = solution(t);
-        // Unfortunately adding typedoc annotations here does not
-        // propagate them up above.
-        return y[0].map((_: any, i: number) => ({
-            name: names[i],
-            x: t,
-            y: y.map((row: number[]) => row[i]),
-        }));
-    };
-}
-
-export function grid(a: number, b: number, len: number) {
-    const dx = (b - a) / (len - 1);
-    const x = [];
-    for (let i = 0; i < len - 1; ++i) {
-        x.push(a + i * dx);
-    }
-    x.push(b);
-    return x;
+    return interpolatedSolution(solution, names, tStart, tEnd);
 }

--- a/test/fit.test.ts
+++ b/test/fit.test.ts
@@ -1,5 +1,5 @@
 import * as models from "./models";
-import {fitTarget, startFit, sumOfSquares} from "../src/fit";
+import {fitTarget, sumOfSquares} from "../src/fit";
 import {UserValue} from "../src/user";
 
 import {approxEqualArray} from "./helpers";
@@ -15,32 +15,3 @@ describe("sumOfSquares", () => {
         expect(sumOfSquares(x, y)).toEqual(70);
     });
 })
-
-
-describe("can fit a simple line", () => {
-    it("Can fit a simple model", () => {
-        const time = [0, 1, 2, 3, 4, 5, 6];
-        const data = {time, value: time.map((t: number) => 1 + t * 4)}
-        const pars = {base: new Map<string, UserValue>([["a", 0.5]]),
-                      vary: ["a"]};
-        const modelledSeries = "x";
-        const controlODE = {};
-        const controlFit = {};
-
-        const opt = startFit(models.User, data, pars, modelledSeries,
-                             controlODE, controlFit);
-        const res = opt.run(100);
-        expect(res.converged).toBe(true);
-        expect(res.location[0]).toBeCloseTo(4);
-        expect(res.value).toBeCloseTo(0);
-        expect(res.data.pars.get("a")).toEqual(res.location[0]);
-
-        const yFit = res.data.solutionFit(0, 6, 7);
-        expect(yFit.name).toEqual("x");
-        expect(yFit.x).toEqual(time);
-        expect(approxEqualArray(yFit.y, data.value)).toBe(true);
-
-        const yFull = res.data.solutionAll(0, 6, 7);
-        expect(yFull).toEqual([yFit]);
-    });
-});

--- a/test/fit.test.ts
+++ b/test/fit.test.ts
@@ -1,0 +1,46 @@
+import * as models from "./models";
+import {fitTarget, startFit, sumOfSquares} from "../src/fit";
+import {UserValue} from "../src/user";
+
+import {approxEqualArray} from "./helpers";
+
+describe("sumOfSquares", () => {
+    const x = [1, 2, 3, 4, 5, 6];
+    it("is zero where no difference", () => {
+        expect(sumOfSquares(x, x)).toEqual(0);
+    });
+
+    it("calculates as expected", () => {
+        const y = [6, 5, 4, 3, 2, 1];
+        expect(sumOfSquares(x, y)).toEqual(70);
+    });
+})
+
+
+describe("can fit a simple line", () => {
+    it("Can fit a simple model", () => {
+        const time = [0, 1, 2, 3, 4, 5, 6];
+        const data = {time, value: time.map((t: number) => 1 + t * 4)}
+        const pars = {base: new Map<string, UserValue>([["a", 0.5]]),
+                      vary: ["a"]};
+        const modelledSeries = "x";
+        const controlODE = {};
+        const controlFit = {};
+
+        const opt = startFit(models.User, data, pars, modelledSeries,
+                             controlODE, controlFit);
+        const res = opt.run(100);
+        expect(res.converged).toBe(true);
+        expect(res.location[0]).toBeCloseTo(4);
+        expect(res.value).toBeCloseTo(0);
+        expect(res.data.pars.get("a")).toEqual(res.location[0]);
+
+        const yFit = res.data.solutionFit(0, 6, 7);
+        expect(yFit.name).toEqual("x");
+        expect(yFit.x).toEqual(time);
+        expect(approxEqualArray(yFit.y, data.value)).toBe(true);
+
+        const yFull = res.data.solutionAll(0, 6, 7);
+        expect(yFull).toEqual([yFit]);
+    });
+});

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,7 +1,9 @@
-import {grid, wodinRun} from "../src/wodin";
+import {wodinRun} from "../src/wodin";
+import {grid} from "../src/model";
 import * as models from "./models";
 import {approxEqualArray} from "./helpers";
 
+// TODO: move this
 describe("grid", () => {
     it("Can produce an array of numbers", () => {
         expect(grid(0, 10, 6)).toEqual([0, 2, 4, 6, 8, 10]);

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,4 +1,4 @@
-import {wodinRun} from "../src/wodin";
+import {wodinFit, wodinRun} from "../src/wodin";
 import {grid} from "../src/model";
 import * as models from "./models";
 import {approxEqualArray} from "./helpers";
@@ -123,4 +123,15 @@ describe("can set user", () => {
         expect(y[0].x).toEqual(expectedX);
         expect(approxEqualArray(y[0].y, expectedY)).toBe(true);
     })
+});
+
+describe("can fit a model", () => {
+    it("fits", () => {
+        const time = [0, 1, 2, 3, 4, 5, 6];
+        const data = {time, value: time.map((t: number) => 1 + t * 4)}
+        const pars = {base: new Map<string, number>([["a", 0.5]]), vary: ["a"]};
+        const opt = wodinFit(models.User, data, pars, "x", {}, {});
+        const res = opt.run(100);
+        expect(res.converged).toBe(true);
+    });
 });

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -125,13 +125,30 @@ describe("can set user", () => {
     })
 });
 
-describe("can fit a model", () => {
-    it("fits", () => {
+describe("can fit a simple line", () => {
+    it("Can fit a simple model", () => {
         const time = [0, 1, 2, 3, 4, 5, 6];
         const data = {time, value: time.map((t: number) => 1 + t * 4)}
-        const pars = {base: new Map<string, number>([["a", 0.5]]), vary: ["a"]};
-        const opt = wodinFit(models.User, data, pars, "x", {}, {});
+        const pars = {base: new Map<string, number>([["a", 0.5]]),
+                      vary: ["a"]};
+        const modelledSeries = "x";
+        const controlODE = {};
+        const controlFit = {};
+
+        const opt = wodinFit(models.User, data, pars, modelledSeries,
+                             controlODE, controlFit);
         const res = opt.run(100);
         expect(res.converged).toBe(true);
+        expect(res.location[0]).toBeCloseTo(4);
+        expect(res.value).toBeCloseTo(0);
+        expect(res.data.pars.get("a")).toEqual(res.location[0]);
+
+        const yFit = res.data.solutionFit(0, 6, 7);
+        expect(yFit.name).toEqual("x");
+        expect(yFit.x).toEqual(time);
+        expect(approxEqualArray(yFit.y, data.value)).toBe(true);
+
+        const yFull = res.data.solutionAll(0, 6, 7);
+        expect(yFull).toEqual([yFit]);
     });
 });


### PR DESCRIPTION
This PR implements fitting using dfoptim in fitting. The docs are fairly spartan because I need to work out how to get it to link across projects, but that's a problem for later I think.

The `wodinFit` function kicks off the optimisation, you then drive it from the methods on the `Simplex` object in `dfoptim`. The additional data object includes `solutionAll` and `pars` which are what the normal "run" tab wants (the solution is the result of the integration for all series', and `pars` is new parameters to update the left hand side with), while `solutionFit` is just the trace that is being fit