### PR TITLE
Basic batch/sensitivity runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@reside-ic/odin",
+    "name": "@reside-ic/odinjs",
     "version": "0.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@reside-ic/odin",
+            "name": "@reside-ic/odinjs",
             "version": "0.0.4",
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/odinjs",
-            "version": "0.0.4",
+            "version": "0.0.5",
             "license": "MIT",
             "dependencies": {
                 "dfoptim": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -78,7 +78,12 @@ export class Batch {
 
     private findExtremes(): Extremes<Series[]> {
         if (this._extremes === undefined) {
-            const n = 51;
+            // Later we'll polish these off with a 1d optimiser from
+            // ~50 points which will be likely faster and more
+            // accurate; that depends on a 1d optimiser added to
+            // dfoptim, then some additional work in findExtremes
+            // (which will need to accept the solution object too).
+            const n = 501;
             const y = this.solution.map(
                 (s: InterpolatedSolution) => s(this.tStart, this.tEnd, n));
             const nms = y[0].map((x: Series) => x.name);

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -39,7 +39,7 @@ export function batchRun(Model: OdinModelConstructable, pars: BatchPars,
                          control: Partial<DopriControlParam>) {
     return pars.values.map((v: number) => {
         const p = updatePars(pars.base, pars.name, v);
-        wodinRun(Model, p, tStart, tEnd, control);
+        return wodinRun(Model, p, tStart, tEnd, control);
     });
 }
 
@@ -106,7 +106,7 @@ export function batchParsDisplace(base: UserType, name: string, count: number,
     return batchParsRange(base, name, count, logarithmic, min, max);
 }
 
-function updatePars(base: UserType, name: string, value: number) {
+export function updatePars(base: UserType, name: string, value: number) {
     const ret = new Map(base);
     ret.set(name, value);
     return ret;

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -16,7 +16,7 @@ export class Batch {
     public readonly tEnd: number;
 
     /** An array of solutions */
-    public readonly solution: InterpolatedSolution[];
+    public readonly solutions: InterpolatedSolution[];
 
     private _extremes?: Extremes<Series[]>;
 
@@ -40,7 +40,7 @@ export class Batch {
         this.pars = pars;
         this.tStart = tStart;
         this.tEnd = tEnd;
-        this.solution = pars.values.map((v: number) => {
+        this.solutions = pars.values.map((v: number) => {
             const p = updatePars(pars.base, pars.name, v);
             return wodinRun(Model, p, tStart, tEnd, control);
         });
@@ -54,7 +54,7 @@ export class Batch {
      * represent the beginning and end of the solution
      */
     public valueAtTime(time: number): Series[] {
-        const y = this.solution.map(
+        const y = this.solutions.map(
             (s: InterpolatedSolution) => s(time, time, 1));
         return y[0].map((_: any, idxSeries: number) => ({
             name: y[0][idxSeries].name,
@@ -84,7 +84,7 @@ export class Batch {
             // dfoptim, then some additional work in findExtremes
             // (which will need to accept the solution object too).
             const n = 501;
-            const y = this.solution.map(
+            const y = this.solutions.map(
                 (s: InterpolatedSolution) => s(this.tStart, this.tEnd, n));
             const nms = y[0].map((x: Series) => x.name);
             const extremes = loop(nms.length, (i: number) =>

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,0 +1,117 @@
+import type { DopriControlParam } from "dopri";
+
+import type { OdinModelConstructable } from "./model";
+import { UserType } from "./user";
+import { grid, gridLog } from "./util";
+import { wodinRun } from "./wodin";
+
+/**
+ * A set of parameters to run in a group, say for a sensitivity
+ * analysis. Consists of a base set of parameters and a single
+ * parameter that takes a range of values.
+ */
+export interface BatchPars {
+    /** The base set of parameters */
+    base: UserType;
+    /** The name of the parameter to vary */
+    name: string;
+    /** The values that `name` will take, replacing the value in `base` */
+    values: number[];
+}
+
+/**
+ * Run a series of runs of an ODE model, returning a set of solutions.
+ *
+ * @param Model The model constructor
+ *
+ * @param pars Parameters of the model, and information about the one
+ * to vary. Most easily generated with {@link batchParsRange} or
+ * {@link batchParsDisplace}.
+ *
+ * @param tStart Start of the integration (often 0)
+ *
+ * @param tEnd End of the integration (must be greater than `tStart`)
+ *
+ * @param control Optional control parameters to tune the integration
+ */
+export function batchRun(Model: OdinModelConstructable, pars: BatchPars,
+                         tStart: number, tEnd: number,
+                         control: Partial<DopriControlParam>) {
+    return pars.values.map((v: number) => {
+        const p = updatePars(pars.base, pars.name, v);
+        wodinRun(Model, p, tStart, tEnd, control);
+    });
+}
+
+/** Generate a set of parameters suitable to pass through to {@param
+ * batchRun}, evenly spaced between `min` and `max`.
+ *
+ * @param base The base set of parameters
+ *
+ * @param name Name of the parameter to change
+ *
+ * @param count The number of traces to run
+ *
+ * @param logarithmic If `true`, the points are spaced on a
+ * logarithmic scale rather than arithmetic.
+ *
+ * @param min Lower bound of the range, must be at most the same as
+ * the current value of `name` witin `base`
+ *
+ * @param max Upper bound of the range, must be at least the same as
+ * the current value of `name` witin `base`
+ */
+export function batchParsRange(base: UserType, name: string, count: number,
+                               logarithmic: boolean,
+                               min: number, max: number): BatchPars {
+    const value = getParameterValueAsNumber(base, name);
+    if (value < min || value > max) {
+        throw Error(`Expected ${value} to lie in [${min}, ${max}]`);
+    }
+    if (count < 2) {
+        throw Error("Must include at least 2 traces in the batch");
+    }
+    const values = logarithmic ?
+        gridLog(min, max, count) : grid(min, max, count);
+    return {base, name, values};
+}
+
+/**
+ * @param base The base set of parameters
+ *
+ * @param name Name of the parameter to change
+ *
+ * @param count The number of traces to run
+ *
+ * @param logarithmic If `true`, the points are spaced on a
+ * logarithmic scale rather than arithmetic.
+ *
+ * @param displace The *percentage* amount to displace the current
+ * value of the parameter `name` (so a value of 15 creates values
+ * ranging from 15% below to 15% above the current value).
+ */
+export function batchParsDisplace(base: UserType, name: string, count: number,
+                                  logarithmic: boolean,
+                                  displace: number): BatchPars {
+    const value = getParameterValueAsNumber(base, name);
+    const min = value * (1 - displace / 100);
+    const max = value * (1 + displace / 100);
+    return batchParsRange(base, name, count, logarithmic, min, max);
+}
+
+function updatePars(base: UserType, name: string, value: number) {
+    const ret = new Map(base);
+    ret.set(name, value);
+    return ret;
+}
+
+function getParameterValueAsNumber(pars: UserType, name: string): number {
+    const value = pars.get(name);
+    if (value === undefined) {
+        throw Error(`Expected a value for '${name}'`);
+    }
+    if (typeof value !== "number") {
+        throw Error(`Expected a number for '${name}'`);
+    }
+    return value;
+}

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -85,11 +85,11 @@ export class Batch {
             const extremes = loop(nms.length, (i: number) =>
                                   y.map((s: Series[]) => findExtremes(s[i])));
             this._extremes = {
-                tMin: extractExtremes("tMin", nms, this.pars.values, extremes),
                 tMax: extractExtremes("tMax", nms, this.pars.values, extremes),
-                yMin: extractExtremes("yMin", nms, this.pars.values, extremes),
+                tMin: extractExtremes("tMin", nms, this.pars.values, extremes),
                 yMax: extractExtremes("yMax", nms, this.pars.values, extremes),
-            }
+                yMin: extractExtremes("yMin", nms, this.pars.values, extremes),
+            };
         }
         return this._extremes;
     }
@@ -239,7 +239,7 @@ function findExtremes(s: Series): Extremes<number> {
 
 function extractExtremes(name: keyof Extremes<number>,
                          names: string[], values: number[],
-                         extremes: Extremes<number>[][]) {
+                         extremes: Array<Array<Extremes<number>>>) {
     return loop(names.length, (i: number) => ({
         name: names[i],
         x: values,

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,6 +1,6 @@
 import type { DopriControlParam } from "dopri";
 
-import type { OdinModelConstructable } from "./model";
+import type { InterpolatedSolution, OdinModelConstructable, Series } from "./model";
 import { UserType } from "./user";
 import { grid, gridLog } from "./util";
 import { wodinRun } from "./wodin";
@@ -121,4 +121,24 @@ function getParameterValueAsNumber(pars: UserType, name: string): number {
         throw Error(`Expected a number for '${name}'`);
     }
     return value;
+}
+
+export class BatchResult {
+    public readonly pars: BatchPars;
+    public readonly solution: InterpolatedSolution[];
+
+    constructor(pars: BatchPars, solution: InterpolatedSolution[]) {
+        this.pars = pars;
+        this.solution = solution;
+    }
+
+    public valueAtTime(time: number): Series[] {
+        const y = this.solution.map(
+            (s: InterpolatedSolution) => s(time, time, 1));
+        return y[0].map((_: any, idxSeries: number) => ({
+            name: y[0][idxSeries].name,
+            x: this.pars.values,
+            y: y.map((s: Series[]) => s[idxSeries].y[0]),
+        }));
+    }
 }

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -65,8 +65,14 @@ export function batchParsRange(base: UserType, name: string, count: number,
                                logarithmic: boolean,
                                min: number, max: number): BatchPars {
     const value = getParameterValueAsNumber(base, name);
-    if (value < min || value > max) {
-        throw Error(`Expected ${value} to lie in [${min}, ${max}]`);
+    if (min > value) {
+        throw Error(`Expected lower bound to be no greater than ${value}`);
+    }
+    if (max < value) {
+        throw Error(`Expected upper bound to be no less than ${value}`);
+    }
+    if (min >= max) {
+        throw Error("Expected upper bound to be greater than lower bound");
     }
     if (count < 2) {
         throw Error("Must include at least 2 traces in the batch");
@@ -94,8 +100,9 @@ export function batchParsDisplace(base: UserType, name: string, count: number,
                                   logarithmic: boolean,
                                   displace: number): BatchPars {
     const value = getParameterValueAsNumber(base, name);
-    const min = value * (1 - displace / 100);
-    const max = value * (1 + displace / 100);
+    const delta = displace / 100;
+    const min = value * (1 - delta);
+    const max = value * (1 + delta);
     return batchParsRange(base, name, count, logarithmic, min, max);
 }
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -43,7 +43,7 @@ export function batchRun(Model: OdinModelConstructable, pars: BatchPars,
     });
 }
 
-/** Generate a set of parameters suitable to pass through to {@param
+/** Generate a set of parameters suitable to pass through to {@link
  * batchRun}, evenly spaced between `min` and `max`.
  *
  * @param base The base set of parameters

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,14 @@ export {PkgWrapper} from "./pkg";
 export {BaseType, base} from "./base";
 export {FitData, FitPars} from "./fit";
 export {
+    InterpolatedSeries,
+    InterpolatedSolution,
     OdinModelConstructable,
     OdinModel,
     OdinModelBase,
     OdinModelODE,
     OdinModelDDE,
+    Series,
     Solution,
 } from "./model";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,11 @@ export {
     OdinModelDDE,
     Solution,
 } from "./model";
+export {
+    BatchPars,
+    batchParsDisplace,
+    batchParsRange,
+    batchRun,
+} from "./batch";
 export {InternalStorage, UserTensor, UserType, UserValue} from "./user";
 export {versions} from "./versions";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@ export {
     Solution,
 } from "./model";
 export {
+    Batch,
     BatchPars,
+    Extremes,
     batchParsDisplace,
     batchParsRange,
     batchRun,

--- a/src/model.ts
+++ b/src/model.ts
@@ -19,6 +19,54 @@ export type Solution = (t: number) => number[];
 export type FullSolution = (t: number[]) => number[][];
 
 /**
+ * A series, compatible with the Plotly interface.
+ */
+export interface Series {
+    /** Name of the series */
+    name: string;
+    /** Values on the x axis, typically time */
+    x: number[];
+    /** Values on the y axis, typically a variable */
+    y: number[];
+}
+
+/**
+ * An interpolated solution to a system of differential equations,
+ * typically created via {@link wodinRun}
+ *
+ * @param t0 Start time to return the solution (cannot be less than
+ * the originally used `tStart` - we will increase it to `tStart` in
+ * that case)
+ *
+ * @param t1 End time to return the solution (cannot be more than the
+ * originally used `tEnd` - we will reduce it to `tEnd` in that case)
+ *
+ * @param nPoints Number of points to return - must be at least
+ * one, and points will be evenly spaced between `t0` and `t1`
+ */
+export type InterpolatedSolution =
+    (t0: number, t1: number, nPoints: number) => Series[];
+
+/**
+ * A single-series interpolated solution, part of the solution to a
+ * system of differential equations (cf {@link InterpolatedSolution},
+ * which represents the full soltion). Used internally by {@link
+ * wodinFit}.
+ *
+ * @param t0 Start time to return the solution (cannot be less than
+ * the originally used `tStart` - we will increase it to `tStart` in
+ * that case)
+ *
+ * @param t1 End time to return the solution (cannot be more than the
+ * originally used `tEnd` - we will reduce it to `tEnd` in that case)
+ *
+ * @param nPoints Number of points to return - must be at least
+ * one, and points will be evenly spaced between `t0` and `t1`
+ */
+export type InterpolatedSeries =
+    (t0: number, t1: number, nPoints: number) => Series;
+
+/**
  * Constructor for an {@link OdinModel}
  *
  * @param base The singleton object {@link base}
@@ -223,30 +271,13 @@ function runModelDDE(model: OdinModelDDE, y0: number[] | null,
  *
  * @param tEnd End time for the integration
  */
-export function interpolatedSolution(solution: FullSolution, names: string[],
-                                     tStart: number, tEnd: number) {
-    /**
-     * @param t0 Start time to return the solution (cannot be less
-     * than `tStart` - we will increase it to `tStart` in that case)
-     *
-     * @param t1 End time to return the solution (cannot be more than
-     * `tEnd` - we will reduce it to `tEnd` in that case)
-     *
-     * @param nPoints Number of points to return - must be at least
-     * two, and points will be evenly spaced between `t0` and `t1`
-     *
-     * @return Returns an array where each element represents a
-     * series. Each element is an object with fields `name` (the name
-     * of the series), `x` (the time values - these will be the same
-     * for every series) and `y` (the series value at each time, the
-     * same length as `x`).
-     */
+export function interpolatedSolution(solution: FullSolution,
+                                     names: string[],
+                                     tStart: number,
+                                     tEnd: number): InterpolatedSolution {
     return (t0: number, t1: number, nPoints: number) => {
         const t = grid(Math.max(tStart, t0), Math.min(tEnd, t1), nPoints);
         const y = solution(t);
-        // Unfortunately adding typedoc annotations here does not
-        // propagate them up above.
-        // TODO: may not be true now?
         return y[0].map((_: any, i: number) => ({
             name: names[i],
             x: t,
@@ -259,8 +290,8 @@ export function interpolatedSolution(solution: FullSolution, names: string[],
  * Conversion function for Dopri output into plotly input for a single
  * series, allowing efficient re-interpolation of subsets of the
  * graph. This is a single-trace version of {@link
- * fullInterpolatedSolution} intended for use with {@link wodinFit}
- * (via {@link fitTarget}).
+ * interpolatedSolution} intended for use with {@link wodinFit} (via
+ * {@link fitTarget}).
  *
  * @param solution The solution as returned from the solver
  *
@@ -274,27 +305,14 @@ export function interpolatedSolution(solution: FullSolution, names: string[],
  * @param tEnd End time for the integration
  */
 export function partialInterpolatedSolution(solution: FullSolution,
-                                            name: string, index: number,
-                                            tStart: number, tEnd: number) {
-    /**
-     * @param t0 Start time to return the solution (cannot be less
-     * than `tStart` - we will increase it to `tStart` in that case)
-     *
-     * @param t1 End time to return the solution (cannot be more than
-     * `tEnd` - we will reduce it to `tEnd` in that case)
-     *
-     * @param nPoints Number of points to return - must be at least
-     * two, and points will be evenly spaced between `t0` and `t1`
-     *
-     * @return Returns an object with fields `name` (the name of the
-     * series), `x` (the time values) and `y` (the series value at
-     * each time, the same length as `x`).
-     */
+                                            name: string,
+                                            index: number,
+                                            tStart: number,
+                                            tEnd: number): InterpolatedSeries {
     return (t0: number, t1: number, nPoints: number) => {
         const t = grid(Math.max(tStart, t0), Math.min(tEnd, t1), nPoints);
         // TODO: we should support this in dopri directly
         const y = solution(t).map((yt) => yt[index]);
-        // Unfortunately typedoc comments not picked up properly here
         return {name, x: t, y};
     };
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,9 +1,9 @@
 import * as dopri from "dopri";
 import type { DopriControlParam } from "dopri";
 
-import {base, BaseType} from "./base";
-
-import {InternalStorage, UserType} from "./user";
+import { base, BaseType } from "./base";
+import { InternalStorage, UserType } from "./user";
+import { grid } from "./util";
 
 /** Interpolated solution to the system of differential equations
  *
@@ -297,14 +297,4 @@ export function partialInterpolatedSolution(solution: FullSolution,
         // Unfortunately typedoc comments not picked up properly here
         return {name, x: t, y};
     };
-}
-
-export function grid(a: number, b: number, len: number) {
-    const dx = (b - a) / (len - 1);
-    const x = [];
-    for (let i = 0; i < len - 1; ++i) {
-        x.push(a + i * dx);
-    }
-    x.push(b);
-    return x;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,13 @@
+export function grid(a: number, b: number, len: number) {
+    const dx = (b - a) / (len - 1);
+    const x = [];
+    for (let i = 0; i < len - 1; ++i) {
+        x.push(a + i * dx);
+    }
+    x.push(b);
+    return x;
+}
+
+export function gridLog(a: number, b: number, len: number) {
+    return grid(Math.log(a), Math.log(b), len).map(Math.exp);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,3 +11,35 @@ export function grid(a: number, b: number, len: number) {
 export function gridLog(a: number, b: number, len: number) {
     return grid(Math.log(a), Math.log(b), len).map(Math.exp);
 }
+
+export function whichMin(x: number[]) {
+    let idx = -1;
+    let min = Infinity;
+    for (let i = 0; i < x.length; ++i) {
+        if (x[i] < min) {
+            idx = i;
+            min = x[i];
+        }
+    }
+    return idx;
+}
+
+export function whichMax(x: number[]) {
+    let idx = -1;
+    let max = -Infinity;
+    for (let i = 0; i < x.length; ++i) {
+        if (x[i] > max) {
+            idx = i;
+            max = x[i];
+        }
+    }
+    return idx;
+}
+
+export function loop<T>(n: number, f: (i: number) => T): T[] {
+    const ret = [];
+    for (let i = 0; i < n; ++i) {
+        ret.push(f(i));
+    }
+    return ret;
+}

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -3,6 +3,6 @@ export function versions() {
     return {
         dfoptim: "0.0.5",
         dopri: "0.0.12",
-        odinjs: "0.0.4",
+        odinjs: "0.0.5",
     };
 }

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -1,0 +1,44 @@
+import { batchParsDisplace, batchParsRange } from "../src/batch";
+import { grid, gridLog } from "../src/util";
+
+describe("Can generate sensible sets of parameters", () => {
+    it("Generates a simple sequence", () => {
+        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const res = batchParsRange(user, "a", 5, false, 0, 2);
+        expect(res.base).toBe(user);
+        expect(res.name).toBe("a");
+        expect(res.values).toEqual(grid(0, 2, 5));
+    });
+
+    it("Generates a logarithmic sequence", () => {
+        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const res = batchParsRange(user, "a", 5, true, 0.5, 1.5);
+        expect(res.base).toBe(user);
+        expect(res.name).toBe("a");
+        expect(res.values).toEqual(gridLog(0.5, 1.5, 5));
+    });
+
+    it("Generates a displaced sequence", () => {
+        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const res = batchParsDisplace(user, "b", 5, false, 50);
+        expect(res.base).toBe(user);
+        expect(res.name).toBe("b");
+        expect(res.values).toEqual(grid(1, 3, 5));
+    });
+
+    it("Requires that central values lie within the requested range", () => {
+        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        expect(() => batchParsRange(user, "a", 5, false, 3, 4))
+            .toThrow("Expected lower bound to be no greater than 1");
+        expect(() => batchParsRange(user, "a", 5, false, -2, -1))
+            .toThrow("Expected upper bound to be no less than 1");
+        expect(() => batchParsRange(user, "a", 5, false, 1, 1))
+            .toThrow("Expected upper bound to be greater than lower bound");
+    })
+
+    it("Requires that we have at least two points in the range", () => {
+        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        expect(() => batchParsRange(user, "a", 1, false, 0, 2))
+            .toThrow("Must include at least 2 traces in the batch");
+    });
+});

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -1,7 +1,8 @@
-import { batchParsDisplace, batchParsRange, batchRun, updatePars } from "../src/batch";
+import { BatchResult, batchParsDisplace, batchParsRange, batchRun, updatePars } from "../src/batch";
 import { grid, gridLog } from "../src/util";
 import { wodinRun } from "../src/wodin";
 
+import { approxEqualArray } from "./helpers";
 import { User } from "./models";
 
 describe("Can generate sensible sets of parameters", () => {
@@ -83,5 +84,25 @@ describe("run sensitivity", () => {
         expect(res[2](tStart, tEnd, n)).toEqual(central(tStart, tEnd, n));
         expect(res[0](tStart, tEnd, n)).toEqual(lower(tStart, tEnd, n));
         expect(res[4](tStart, tEnd, n)).toEqual(upper(tStart, tEnd, n));
+    });
+});
+
+
+describe("can extract from a batch result", () => {
+    // TODO: we need a model with both parameters and multiple traces
+    // here to confirm this is correct.
+    it("Extracts state at a particular time", () => {
+        const user = new Map<string, number>([["a", 2]]);
+        const pars = batchParsRange(user, "a", 5, false, 0, 4);
+        const control = {};
+        const tStart = 0;
+        const tEnd = 10;
+        const sol = batchRun(User, pars, tStart, tEnd, control);
+        const obj = new BatchResult(pars, sol);
+        const res = obj.valueAtTime(tEnd);
+        expect(res.length).toBe(1); // just one series here
+        expect(res[0].name).toBe("x");
+        expect(res[0].x).toEqual(grid(0, 4, 5));
+        expect(approxEqualArray(res[0].y, [1, 11, 21, 31, 41])).toBe(true);
     });
 });

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -90,7 +90,6 @@ describe("run sensitivity", () => {
     });
 });
 
-
 describe("can extract from a batch result", () => {
     // TODO: we need a model with both parameters and multiple traces
     // here to confirm this is correct.

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -81,11 +81,11 @@ describe("run sensitivity", () => {
         const upper = wodinRun(User, new Map<string, number>([["a", 4]]),
                                tStart, tEnd, control);
         const n = 11;
-        expect(res.solution[2](tStart, tEnd, n))
+        expect(res.solutions[2](tStart, tEnd, n))
             .toEqual(central(tStart, tEnd, n));
-        expect(res.solution[0](tStart, tEnd, n))
+        expect(res.solutions[0](tStart, tEnd, n))
             .toEqual(lower(tStart, tEnd, n));
-        expect(res.solution[4](tStart, tEnd, n))
+        expect(res.solutions[4](tStart, tEnd, n))
             .toEqual(upper(tStart, tEnd, n));
     });
 });

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -1,4 +1,4 @@
-import { BatchResult, batchParsDisplace, batchParsRange, batchRun, updatePars } from "../src/batch";
+import { batchParsDisplace, batchParsRange, batchRun, updatePars } from "../src/batch";
 import { grid, gridLog } from "../src/util";
 import { wodinRun } from "../src/wodin";
 
@@ -81,9 +81,12 @@ describe("run sensitivity", () => {
         const upper = wodinRun(User, new Map<string, number>([["a", 4]]),
                                tStart, tEnd, control);
         const n = 11;
-        expect(res[2](tStart, tEnd, n)).toEqual(central(tStart, tEnd, n));
-        expect(res[0](tStart, tEnd, n)).toEqual(lower(tStart, tEnd, n));
-        expect(res[4](tStart, tEnd, n)).toEqual(upper(tStart, tEnd, n));
+        expect(res.solution[2](tStart, tEnd, n))
+            .toEqual(central(tStart, tEnd, n));
+        expect(res.solution[0](tStart, tEnd, n))
+            .toEqual(lower(tStart, tEnd, n));
+        expect(res.solution[4](tStart, tEnd, n))
+            .toEqual(upper(tStart, tEnd, n));
     });
 });
 
@@ -97,8 +100,7 @@ describe("can extract from a batch result", () => {
         const control = {};
         const tStart = 0;
         const tEnd = 10;
-        const sol = batchRun(User, pars, tStart, tEnd, control);
-        const obj = new BatchResult(pars, tStart, tEnd, sol);
+        const obj = batchRun(User, pars, tStart, tEnd, control);
         const res = obj.valueAtTime(tEnd);
         expect(res.length).toBe(1); // just one series here
         expect(res[0].name).toBe("x");
@@ -112,8 +114,7 @@ describe("can extract from a batch result", () => {
         const control = {};
         const tStart = 0;
         const tEnd = 10;
-        const sol = batchRun(Output, pars, tStart, tEnd, control);
-        const obj = new BatchResult(pars, tStart, tEnd, sol);
+        const obj = batchRun(Output, pars, tStart, tEnd, control);
         const res = obj.valueAtTime(tEnd);
         expect(res.length).toBe(2);
         expect(res[0].name).toBe("x");

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -3,7 +3,7 @@ import { grid, gridLog } from "../src/util";
 import { wodinRun } from "../src/wodin";
 
 import { approxEqualArray } from "./helpers";
-import { User } from "./models";
+import { Output, User } from "./models";
 
 describe("Can generate sensible sets of parameters", () => {
     it("Generates a simple sequence", () => {
@@ -98,11 +98,32 @@ describe("can extract from a batch result", () => {
         const tStart = 0;
         const tEnd = 10;
         const sol = batchRun(User, pars, tStart, tEnd, control);
-        const obj = new BatchResult(pars, sol);
+        const obj = new BatchResult(pars, tStart, tEnd, sol);
         const res = obj.valueAtTime(tEnd);
         expect(res.length).toBe(1); // just one series here
         expect(res[0].name).toBe("x");
         expect(res[0].x).toEqual(grid(0, 4, 5));
         expect(approxEqualArray(res[0].y, [1, 11, 21, 31, 41])).toBe(true);
+    });
+
+    it("Extracts state at a particular time for multivariable models", () => {
+        const user = new Map<string, number>([["a", 2]]);
+        const pars = batchParsRange(user, "a", 5, false, 0, 4);
+        const control = {};
+        const tStart = 0;
+        const tEnd = 10;
+        const sol = batchRun(Output, pars, tStart, tEnd, control);
+        const obj = new BatchResult(pars, tStart, tEnd, sol);
+        const res = obj.valueAtTime(tEnd);
+        expect(res.length).toBe(2);
+        expect(res[0].name).toBe("x");
+        expect(res[1].name).toBe("y");
+        expect(res[0].x).toEqual(grid(0, 4, 5));
+        expect(approxEqualArray(res[0].y, [1, 11, 21, 31, 41])).toBe(true);
+        const e = obj.extreme("yMax");
+        expect(e.length).toBe(2);
+        expect(e[0].name).toBe("x");
+        expect(e[0].x).toEqual(grid(0, 4, 5));
+        expect(approxEqualArray(e[0].y, [1, 11, 21, 31, 41])).toBe(true);
     });
 });

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -1,5 +1,8 @@
-import { batchParsDisplace, batchParsRange } from "../src/batch";
+import { batchParsDisplace, batchParsRange, batchRun, updatePars } from "../src/batch";
 import { grid, gridLog } from "../src/util";
+import { wodinRun } from "../src/wodin";
+
+import { User } from "./models";
 
 describe("Can generate sensible sets of parameters", () => {
     it("Generates a simple sequence", () => {
@@ -40,5 +43,45 @@ describe("Can generate sensible sets of parameters", () => {
         const user = new Map<string, number>([["a", 1], ["b", 2]]);
         expect(() => batchParsRange(user, "a", 1, false, 0, 2))
             .toThrow("Must include at least 2 traces in the batch");
+    });
+
+    it("Requires that the updated parameter exists", () => {
+        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        expect(() => batchParsRange(user, "c", 5, false, 0, 2))
+            .toThrow("Expected a value for 'c'");
+    });
+
+    it("Requires a scalar for the updated parameter", () => {
+        const user = new Map<string, number | number[]>([["a", [1, 2]]]);
+        expect(() => batchParsRange(user, "a", 5, false, 0, 2))
+            .toThrow("Expected a number for 'a'");
+    });
+
+    it("Updates parameter values correctly", () => {
+        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const p = updatePars(user, "a", 3);
+        expect(p.get("a")).toBe(3);
+        expect(p.get("b")).toBe(2);
+    });
+});
+
+describe("run sensitivity", () => {
+    it("runs without error", () => {
+        const user = new Map<string, number>([["a", 2]]);
+        const pars = batchParsRange(user, "a", 5, false, 0, 4);
+        const control = {};
+        const tStart = 0;
+        const tEnd = 10;
+        const res = batchRun(User, pars, tStart, tEnd, control);
+
+        const central = wodinRun(User, user, tStart, tEnd, control);
+        const lower = wodinRun(User, new Map<string, number>([["a", 0]]),
+                               tStart, tEnd, control);
+        const upper = wodinRun(User, new Map<string, number>([["a", 4]]),
+                               tStart, tEnd, control);
+        const n = 11;
+        expect(res[2](tStart, tEnd, n)).toEqual(central(tStart, tEnd, n));
+        expect(res[0](tStart, tEnd, n)).toEqual(lower(tStart, tEnd, n));
+        expect(res[4](tStart, tEnd, n)).toEqual(upper(tStart, tEnd, n));
     });
 });

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -37,7 +37,7 @@ describe("Can generate sensible sets of parameters", () => {
             .toThrow("Expected upper bound to be no less than 1");
         expect(() => batchParsRange(user, "a", 5, false, 1, 1))
             .toThrow("Expected upper bound to be greater than lower bound");
-    })
+    });
 
     it("Requires that we have at least two points in the range", () => {
         const user = new Map<string, number>([["a", 1], ["b", 2]]);

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,5 +1,5 @@
 import {wodinFit, wodinRun} from "../src/wodin";
-import {grid} from "../src/model";
+import { grid } from "../src/util";
 import * as models from "./models";
 import {approxEqualArray} from "./helpers";
 


### PR DESCRIPTION
I expect that this will be more of a starting point for discussion, but it pulls in the logic that exists in the existing shiny app at least. It may be that this is better in wodin itself, but this may be easier to work with than digging through the shiny code in that case.

`batchRun` is very much a placeholder:

 - it's super simple so perhaps something that you want to run in the frontend?
 - there's no need to make it blocking and run everything in one go
 - if we do keep it as-is-ish it needs renaming as this is probably wodinBatchRun really (it calls wodinRun)
 - if we change it to update the plots incrementally we should change how we generate numbers to interleave them from closest to furthest

Some of this will depend a bit on how fast this is to run in practice - it was probably slow on the shiny version because of the vast amount of data being serialised to json and posted around