### PR TITLE
Add support for interpolated functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.6",
+    "version": "0.0.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/odinjs",
-            "version": "0.0.6",
+            "version": "0.0.8",
             "license": "MIT",
             "dependencies": {
                 "@reside-ic/interpolate": "^0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.6",
             "license": "MIT",
             "dependencies": {
+                "@reside-ic/interpolate": "^0.0.1",
                 "dfoptim": "^0.0.5",
                 "dopri": "^0.0.12"
             },
@@ -992,6 +993,14 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "node_modules/@reside-ic/interpolate": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@reside-ic/interpolate/-/interpolate-0.0.1.tgz",
+            "integrity": "sha512-IXPRSxQsmil3ouEWdmzj/aWbzygCcBU9B4W8RKDHP4WK1AY8fCxltnUGS/puyVMxEhFEAksYIhGtp3kyPC0dsA==",
+            "dependencies": {
+                "solve-tridiagonal": "^2.0.0"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -4190,6 +4199,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/solve-tridiagonal": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/solve-tridiagonal/-/solve-tridiagonal-2.0.0.tgz",
+            "integrity": "sha512-COIAUGxielrXcrDQbdrYN5vktUX/7ND05dmGBd1o4bnfPVf8yCke4rChVBFxqkZGjAQITLuLydHIPUPPBIYZeg=="
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5852,6 +5866,14 @@
             "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "@reside-ic/interpolate": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@reside-ic/interpolate/-/interpolate-0.0.1.tgz",
+            "integrity": "sha512-IXPRSxQsmil3ouEWdmzj/aWbzygCcBU9B4W8RKDHP4WK1AY8fCxltnUGS/puyVMxEhFEAksYIhGtp3kyPC0dsA==",
+            "requires": {
+                "solve-tridiagonal": "^2.0.0"
             }
         },
         "@sinclair/typebox": {
@@ -8342,6 +8364,11 @@
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
+        },
+        "solve-tridiagonal": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/solve-tridiagonal/-/solve-tridiagonal-2.0.0.tgz",
+            "integrity": "sha512-COIAUGxielrXcrDQbdrYN5vktUX/7ND05dmGBd1o4bnfPVf8yCke4rChVBFxqkZGjAQITLuLydHIPUPPBIYZeg=="
         },
         "source-map": {
             "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
+        "@reside-ic/interpolate": "^0.0.1",
         "dfoptim": "^0.0.5",
         "dopri": "^0.0.12"
     }

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,6 +1,7 @@
 import {delay} from "./delay";
+import {interpolate} from "./interpolate";
 import {maths} from "./maths";
 import {user} from "./user";
 
-export const base = {delay, maths, user};
+export const base = {delay, interpolate, maths, user};
 export type BaseType = typeof base;

--- a/src/interpolate.ts
+++ b/src/interpolate.ts
@@ -26,12 +26,13 @@ interface InterpolateTimes {
  */
 export function interpolateAlloc(method: string,
                                  t: number[], y: number[]): InterpolatorBase {
+    const yy = tensorToArray(y, t.length);
     if (method === "constant") {
-        return new InterpolatorConstant(t, y);
+        return new InterpolatorConstant(t, yy);
     } else if (method === "linear") {
-        return new InterpolatorLinear(t, y);
+        return new InterpolatorLinear(t, yy);
     } else if (method === "spline") {
-        return new InterpolatorSpline(t, y);
+        return new InterpolatorSpline(t, yy);
     } else {
         throw Error(`Invalid interpolation method '${method}'`);
     }
@@ -100,3 +101,15 @@ export const interpolate = {
     checkY: interpolateCheckY,
     times: interpolateTimes,
 };
+
+function tensorToArray(y: number[], len: number) {
+    if (y.length === len) {
+        return [y];
+    }
+    const ret = [];
+    const n = y.length / len;
+    for (let i = 0; i < n; ++i) {
+        ret.push(y.slice(len * i, len * (i + 1)));
+    }
+    return ret;
+}

--- a/src/interpolate.ts
+++ b/src/interpolate.ts
@@ -1,0 +1,102 @@
+import {
+    InterpolatorBase,
+    InterpolatorConstant,
+    InterpolatorLinear,
+    InterpolatorSpline,
+} from "@reside-ic/interpolate";
+
+/**
+ * Information about interpolation bounds
+ */
+interface InterpolateTimes {
+    /** The minimum time supported by the interpolation functions */
+    max: number;
+    /** The maximum time supported by the interpolation functions */
+    min: number;
+}
+
+/** Allocate a new interpolation function object
+ *
+ * @param method Interpolation method to use; one of `constant`,
+ * `linear` or `spline`
+ *
+ * @param t Array of interpolation times
+ *
+ * @param y Array of interpolation response variables
+ */
+export function interpolateAlloc(method: string,
+                                 t: number[], y: number[]): InterpolatorBase {
+    if (method === "constant") {
+        return new InterpolatorConstant(t, y);
+    } else if (method === "linear") {
+        return new InterpolatorLinear(t, y);
+    } else if (method === "spline") {
+        return new InterpolatorSpline(t, y);
+    } else {
+        throw Error(`Invalid interpolation method '${method}'`);
+    }
+}
+
+/** Check that interpolation values are reasonable; this is called
+ * before allocation, once per model initialisation or parameter
+ * setting
+ */
+export function interpolateCheckY(dimArg: number[], dimTarget: number[],
+                                  nameArg: string, nameTarget: string) {
+    if (dimTarget.length === 1) {
+        if (dimArg[0] !== dimTarget[0]) {
+            throw Error(`Expected ${nameArg} to have length ${dimArg[0]}` +
+                        ` (for ${nameTarget})`);
+        }
+    } else {
+        for (let i = 0; i < dimTarget.length; ++i) {
+            if (dimArg[i] !== dimTarget[i]) {
+                throw Error(`Expected dimension ${i + 1} of ${nameArg}` +
+                            ` to have size ${dimArg[i]} (for ${nameTarget})`);
+            }
+        }
+    }
+}
+
+/** Check that the integration times are compatible with the
+ * interpolation functions (i.e., that they would not cause
+ * extrapolation). If the model does not have
+ *
+ * @param tStart Start time of the integration
+ *
+ * @param tEnd End time of the integration
+ *
+ * @param times Information about the interpolation bounds
+ */
+export function interpolateCheckT(tStart: number, tEnd: number,
+                                  times?: InterpolateTimes) {
+    if (times === undefined) {
+        return Infinity;
+    }
+    if (tStart < times.min) {
+        throw Error("Integration times do not span interpolation range;" +
+                    ` min: ${times.min}`);
+    }
+    if (tEnd > times.max) {
+        throw Error("Integration times do not span interpolation range;" +
+                    ` max: ${times.max}`);
+    }
+    // This logic needs tweaking once we expose the critical time
+    // interface more broadly (i.e., where any model can add a
+    // critical time; mrc-3418)
+    return times.max;
+}
+
+export function interpolateTimes(start: number[], end: number[]): InterpolateTimes {
+    // min time would be the latest (max) interpolation start
+    const min = Math.max(...start);
+    // max time would be the earliest (min) interpolation end
+    const max = Math.min(...end);
+    return {max, min};
+}
+
+export const interpolate = {
+    alloc: interpolateAlloc,
+    checkY: interpolateCheckY,
+    times: interpolateTimes,
+};

--- a/src/interpolate.ts
+++ b/src/interpolate.ts
@@ -68,9 +68,13 @@ export function interpolateCheckY(dimArg: number[], dimTarget: number[],
  * @param tEnd End time of the integration
  *
  * @param times Information about the interpolation bounds
+ *
+ * @param tcrit The critical time to stop the model - if given we
+ * won't set this based on the interpolation end time.
  */
 export function interpolateCheckT(tStart: number, tEnd: number,
-                                  times?: InterpolateTimes) {
+                                  times?: InterpolateTimes,
+                                  tcrit?: number) {
     if (times === undefined) {
         return Infinity;
     }
@@ -82,10 +86,19 @@ export function interpolateCheckT(tStart: number, tEnd: number,
         throw Error("Integration times do not span interpolation range;" +
                     ` max: ${times.max}`);
     }
-    // This logic needs tweaking once we expose the critical time
-    // interface more broadly (i.e., where any model can add a
-    // critical time; mrc-3418)
-    return times.max;
+
+    // See odin (R/generate_r_support.R:support_check_interpolate_t)
+    // It would be better to add an else clause to this containing
+    //
+    // tcrit = Math.min(tcrit, times.max);
+    //
+    // but this requires updating odin tests and the other
+    // targets. It's probably the correct behaviour though.
+    if (tcrit === undefined) {
+        tcrit = times.max;
+    }
+
+    return tcrit;
 }
 
 export function interpolateTimes(start: number[], end: number[]): InterpolateTimes {

--- a/src/interpolate.ts
+++ b/src/interpolate.ts
@@ -61,7 +61,9 @@ export function interpolateCheckY(dimArg: number[], dimTarget: number[],
 
 /** Check that the integration times are compatible with the
  * interpolation functions (i.e., that they would not cause
- * extrapolation). If the model does not have
+ * extrapolation). If the model does not require interpolation then
+ * this will set a critical time of `Infinity` (i.e., there is no
+ * point the solver should stop before).
  *
  * @param tStart Start time of the integration
  *

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,6 +2,7 @@ import * as dopri from "dopri";
 import type { DopriControlParam } from "dopri";
 
 import { base, BaseType } from "./base";
+import { interpolateCheckT } from "./interpolate";
 import { InternalStorage, UserType } from "./user";
 import { grid } from "./util";
 
@@ -197,6 +198,8 @@ export type OdinModel = OdinModelODE | OdinModelDDE;
 export function runModel(model: OdinModel, y0: number[] | null,
                          tStart: number, tEnd: number,
                          control: Partial<DopriControlParam>) {
+    const interpolateTimes = model.getMetadata().interpolateTimes;
+    control.tcrit = interpolateCheckT(tStart, tEnd, interpolateTimes);
     return isDDEModel(model) ?
         runModelDDE(model as OdinModelDDE, y0, tStart, tEnd, control) :
         runModelODE(model as OdinModelODE, y0, tStart, tEnd, control);

--- a/src/model.ts
+++ b/src/model.ts
@@ -199,7 +199,8 @@ export function runModel(model: OdinModel, y0: number[] | null,
                          tStart: number, tEnd: number,
                          control: Partial<DopriControlParam>) {
     const interpolateTimes = model.getMetadata().interpolateTimes;
-    control.tcrit = interpolateCheckT(tStart, tEnd, interpolateTimes);
+    control.tcrit = interpolateCheckT(tStart, tEnd, interpolateTimes,
+                                      control.tcrit);
     return isDDEModel(model) ?
         runModelDDE(model as OdinModelDDE, y0, tStart, tEnd, control) :
         runModelODE(model as OdinModelODE, y0, tStart, tEnd, control);

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -3,6 +3,6 @@ export function versions() {
     return {
         dfoptim: "0.0.5",
         dopri: "0.0.12",
-        odinjs: "0.0.6",
+        odinjs: "0.0.8",
     };
 }

--- a/test/interpolate.test.ts
+++ b/test/interpolate.test.ts
@@ -28,6 +28,8 @@ describe("Can validate interpolation times", () => {
     it("Can report back tcrit from interpolation times", () => {
         const t = {min: 0, max: 11};
         expect(interpolateCheckT(0, 10, t)).toBe(11);
+        expect(interpolateCheckT(0, 10, t, 10.5)).toBe(10.5);
+        expect(interpolateCheckT(0, 10, t, 11.5)).toBe(11.5);
     });
 
     it("Requires that integration times do not extrapolate", () => {

--- a/test/interpolate.test.ts
+++ b/test/interpolate.test.ts
@@ -1,0 +1,74 @@
+import {interpolateAlloc, interpolateCheckT, interpolateCheckY, interpolateTimes} from "../src/interpolate";
+
+describe("Can validate interpolation argumements", () => {
+    it("accepts valid inputs", () => {
+        interpolateCheckY([10], [10], "x", "y");
+        interpolateCheckY([10, 2, 5], [10, 2, 5], "x", "y");
+    });
+
+    it("rejects incorrectly sized vector inputs", () => {
+        expect(() => interpolateCheckY([10], [9], "x", "y")).
+            toThrow("Expected x to have length 10 (for y)");
+        expect(() => interpolateCheckY([10, 2, 5], [9, 2, 5], "x", "y")).
+            toThrow("Expected dimension 1 of x to have size 10 (for y)");
+    });
+});
+
+describe("Can validate interpolation times", () => {
+    it("Requires no tcrit with no interpolationTimes", () => {
+        expect(interpolateCheckT(0, 10)).toBe(Infinity);
+        expect(interpolateCheckT(0, 10, undefined)).toBe(Infinity);
+    });
+
+    it("Requires no tcrit with no max interpolation time", () => {
+        const t = {min: 0, max: Infinity};
+        expect(interpolateCheckT(0, 10, t)).toBe(Infinity);
+    });
+
+    it("Can report back tcrit from interpolation times", () => {
+        const t = {min: 0, max: 11};
+        expect(interpolateCheckT(0, 10, t)).toBe(11);
+    });
+
+    it("Requires that integration times do not extrapolate", () => {
+        const t = {min: 0, max: 10};
+        expect(() => interpolateCheckT(-5, 10, t))
+            .toThrow("Integration times do not span interpolation range; min: 0");
+        expect(() => interpolateCheckT(0, 20, t))
+            .toThrow("Integration times do not span interpolation range; max: 10");
+    });
+
+    it("constructs sensible interpolation times", () => {
+        expect(interpolateTimes([], [])).toEqual({min: -Infinity, max: Infinity});
+        expect(interpolateTimes([3, 2, 1], [])).toEqual({min: 3, max: Infinity});
+        expect(interpolateTimes([3, 2, 1], [5, 6, 7])).toEqual({min: 3, max: 5});
+    });
+});
+
+describe("Can construct interpolation objects", () => {
+    const t = [0, 1, 2, 3, 4, 5, 6];
+    const y = t.map((x: number) => x * x);
+
+    it("constructs constant interpolators", () => {
+        const obj = interpolateAlloc("constant", t, y);
+        expect(obj.eval(3, 0)).toEqual(9);
+        expect(obj.eval(3.5, 0)).toEqual(9);
+    });
+
+    it("constructs linear interpolators", () => {
+        const obj = interpolateAlloc("linear", t, y);
+        expect(obj.eval(3, 0)).toEqual(9);
+        expect(obj.eval(3.5, 0)).toEqual(12.5);
+    });
+
+    it("constructs spline interpolators", () => {
+        const obj = interpolateAlloc("spline", t, y);
+        expect(obj.eval(3, 0)).toEqual(9);
+        expect(obj.eval(3.5, 0)).toBeCloseTo(12.2548077);
+    });
+
+    it("refuses to construct unknown interpolators", () => {
+        expect(() => interpolateAlloc("other", t, y))
+            .toThrow("Invalid interpolation method 'other'");
+    });
+});

--- a/test/models.ts
+++ b/test/models.ts
@@ -273,7 +273,7 @@ export class InterpolateSpline {
 
     rhs(t, state, dstatedt) {
         var internal = this.internal;
-        var pulse = t.eval(internal.interpolate_pulse, 0);
+        var pulse = internal.interpolate_pulse.eval(t, 0);
         dstatedt[0] = pulse;
     }
 
@@ -291,6 +291,7 @@ export class InterpolateSpline {
         this.metadata.internalOrder = {dim_tp: null, dim_zp: null, initial_y: null, tp: internal.dim_tp, zp: internal.dim_zp};
         this.metadata.variableOrder = {y: null};
         this.metadata.outputOrder = null;
+        this.metadata.interpolateTimes = this.base.interpolate.times([internal.tp[0]], [internal.tp[internal.dim_tp - 1]]);
     }
 
     setUser(user, unusedUserAction) {
@@ -302,9 +303,8 @@ export class InterpolateSpline {
         var dim_zp = new Array(2);
         this.base.user.setUserArrayVariable(user, "zp", internal, dim_zp, -Infinity, Infinity, false);
         internal.dim_zp = dim_zp[0];
-        base.interpolate.CheckY([internal.dim_tp], [internal.dim_zp], "zp", "pulse");
-        internal.interpolate_pulse = base.interpolate.alloc("spline", internal.tp, internal.zp)
-        this.metadata.interpolateTimes = this.base.interpolateTimes([internal.tp[0]], [internal.tp[internal.dim_tp - 1]]);
+        this.base.interpolate.checkY([internal.dim_tp], [internal.dim_zp], "zp", "pulse");
+        internal.interpolate_pulse = this.base.interpolate.alloc("spline", internal.tp, internal.zp)
         this.updateMetadata();
     }
 

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -93,11 +93,11 @@ describe("can run basic models", () => {
         const zp = tp.map((t: number) => Math.sin(t));
         const user = new Map<string, number | number[]>([["tp", tp], ["zp", zp]]);
         const control : any = {};
-        const solution = wodinRun(models.InterpolateSpline, user, 0, 3, control);
+        const solution = wodinRun(models.InterpolateSpline, user, 0, pi, control);
 
-        const expectedT = grid(0, 3, 11);
+        const expectedT = grid(0, pi, 11);
         const expectedY = expectedT.map((t: number) => 1 - Math.cos(t));
-        const y = solution(0, 3, 11);
+        const y = solution(0, pi, 11);
         expect(approxEqualArray(y[0].y, expectedY, 1e-4)).toBe(true);
     });
 });

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,5 +1,7 @@
 import { wodinFit, wodinFitBaseline, wodinRun } from "../src/wodin";
-import { grid } from "../src/util";
+import {UserTensor, UserValue} from "../src/user";
+import {grid} from "../src/util";
+
 import * as models from "./models";
 import {approxEqualArray} from "./helpers";
 
@@ -99,6 +101,20 @@ describe("can run basic models", () => {
         const expectedY = expectedT.map((t: number) => 1 - Math.cos(t));
         const y = solution(0, pi, 11);
         expect(approxEqualArray(y[0].y, expectedY, 1e-4)).toBe(true);
+    });
+
+    it("runs a model with interpolated arrays", () => {
+        const tp = [0, 1, 2];
+        const zp: UserTensor = {data: [0, 1, 0, 0, 2, 0], dim: [3, 2]};
+        const user = new Map<string, UserValue>([["tp", tp], ["zp", zp]]);
+        const control: any = {};
+        const solution = wodinRun(models.InterpolateArray, user, 0, 3, control);
+        const y = solution(0, 3, 51);
+        const t = y[0].x;
+        const z1 = t.map((t: number) => t < 1 ? 0 : (t > 2 ? 1 : t - 1));
+        const z2 = t.map((t: number) => t < 1 ? 0 : (t > 2 ? 2 : 2 * (t - 1)));
+        expect(approxEqualArray(y[0].y, z1, 6e-5)).toBe(true);
+        expect(approxEqualArray(y[1].y, z2, 6e-5)).toBe(true);
     });
 });
 

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -86,6 +86,20 @@ describe("can run basic models", () => {
         expect(y[1].x).toEqual(expectedT);
         expect(approxEqualArray(y[1].y, expectedY, 1e-3)).toBe(true);
     });
+
+    it("runs a model with interpolation", () => {
+        const pi = Math.PI;
+        const tp = grid(0, pi, 31);
+        const zp = tp.map((t: number) => Math.sin(t));
+        const user = new Map<string, number | number[]>([["tp", tp], ["zp", zp]]);
+        const control : any = {};
+        const solution = wodinRun(models.InterpolateSpline, user, 0, pi, control);
+
+        const expectedT = grid(0, 10, 11);
+        const expectedY = expectedT.map((t: number) => 1 - Math.cos(t));
+        const y = solution(0, pi, 101);
+        expect(approxEqualArray(y[0].y, expectedY, 1e-4)).toBe(true);
+    });
 });
 
 describe("can set user", () => {

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -93,11 +93,11 @@ describe("can run basic models", () => {
         const zp = tp.map((t: number) => Math.sin(t));
         const user = new Map<string, number | number[]>([["tp", tp], ["zp", zp]]);
         const control : any = {};
-        const solution = wodinRun(models.InterpolateSpline, user, 0, pi, control);
+        const solution = wodinRun(models.InterpolateSpline, user, 0, 3, control);
 
-        const expectedT = grid(0, 10, 11);
+        const expectedT = grid(0, 3, 11);
         const expectedY = expectedT.map((t: number) => 1 - Math.cos(t));
-        const y = solution(0, pi, 101);
+        const y = solution(0, 3, 11);
         expect(approxEqualArray(y[0].y, expectedY, 1e-4)).toBe(true);
     });
 });


### PR DESCRIPTION
Getting ahead of the wodin needs here, but towards being able to merge into odin. This PR adds support for models that include interpolation function, mimicking the interfaces for the R and C targets, using the new interpolate package.

I have opened a parallel PR on odin that uses the code from this PR: https://github.com/mrc-ide/odin/pull/267