### PR TITLE
Sum of squares should allow missing values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/odinjs",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "MIT",
             "dependencies": {
                 "dfoptim": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -3,6 +3,8 @@ import type { OdinModelConstructable, Solution } from "./model";
 import {interpolatedSolution, partialInterpolatedSolution, runModel} from "./model";
 import type {UserType} from "./user";
 
+export type nullableArray<T> = Array<T | null>;
+
 /** Interface for data to fit an odin model to; every data set has two
  *  series, even if they are derived from some larger data set.
  */
@@ -70,10 +72,13 @@ export function updatePars(pars: FitPars, theta: number[]) {
     return ret;
 }
 
-export function sumOfSquares(x: number[], y: number[]) {
+export function sumOfSquares(x: (number | null)[], y: number[]) {
     let tot = 0;
     for (let i = 0; i < x.length; ++i) {
-        tot += (x[i] - y[i]) ** 2;
+        const xi = x[i];
+        if (xi !== null) {
+            tot += (xi - y[i]) ** 2;
+        }
     }
     return tot;
 }

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -3,8 +3,6 @@ import type { OdinModelConstructable, Solution } from "./model";
 import {interpolatedSolution, partialInterpolatedSolution, runModel} from "./model";
 import type {UserType} from "./user";
 
-export type nullableArray<T> = Array<T | null>;
-
 /** Interface for data to fit an odin model to; every data set has two
  *  series, even if they are derived from some larger data set.
  */
@@ -12,10 +10,10 @@ export interface FitData {
     /** Array of time values; must be increasing */
     time: number[];
     /** Observed data to fit to; must be the same length as
-     * `time`. Missing values (`null`) are allowed, and are ignored in
+     * `time`. Missing values (`NaN`) are allowed, and are ignored in
      * the fit.
      */
-    value: nullableArray<number>;
+    value: number[];
 }
 
 /** Interface to control parameters of a fit. A model will have some
@@ -75,11 +73,11 @@ export function updatePars(pars: FitPars, theta: number[]) {
     return ret;
 }
 
-export function sumOfSquares(x: nullableArray<number>, y: number[]) {
+export function sumOfSquares(x: number[], y: number[]) {
     let tot = 0;
     for (let i = 0; i < x.length; ++i) {
         const xi = x[i];
-        if (xi !== null && !isNaN(xi)) {
+        if (!isNaN(xi)) {
             tot += (xi - y[i]) ** 2;
         }
     }

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -11,8 +11,11 @@ export type nullableArray<T> = Array<T | null>;
 export interface FitData {
     /** Array of time values; must be increasing */
     time: number[];
-    /** Observed data to fit to; must be the same length as `time` */
-    value: number[];
+    /** Observed data to fit to; must be the same length as
+     * `time`. Missing values (`null`) are allowed, and are ignored in
+     * the fit.
+     */
+    value: nullableArray<number>;
 }
 
 /** Interface to control parameters of a fit. A model will have some
@@ -72,11 +75,11 @@ export function updatePars(pars: FitPars, theta: number[]) {
     return ret;
 }
 
-export function sumOfSquares(x: (number | null)[], y: number[]) {
+export function sumOfSquares(x: nullableArray<number>, y: number[]) {
     let tot = 0;
     for (let i = 0; i < x.length; ++i) {
         const xi = x[i];
-        if (xi !== null) {
+        if (xi !== null && !isNaN(xi)) {
             tot += (xi - y[i]) ** 2;
         }
     }

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -3,6 +3,6 @@ export function versions() {
     return {
         dfoptim: "0.0.5",
         dopri: "0.0.12",
-        odinjs: "0.0.5",
+        odinjs: "0.0.6",
     };
 }

--- a/test/fit.test.ts
+++ b/test/fit.test.ts
@@ -14,4 +14,9 @@ describe("sumOfSquares", () => {
         const y = [6, 5, 4, 3, 2, 1];
         expect(sumOfSquares(x, y)).toEqual(70);
     });
+
+    it("allows missing values", () => {
+        expect(sumOfSquares([2, 3, null, 5, 6, 7], x)).toEqual(5);
+        expect(sumOfSquares(Array(6).fill(null), x)).toEqual(0);
+    });
 })

--- a/test/fit.test.ts
+++ b/test/fit.test.ts
@@ -16,8 +16,6 @@ describe("sumOfSquares", () => {
     });
 
     it("allows missing values", () => {
-        expect(sumOfSquares([2, 3, null, 5, 6, 7], x)).toEqual(5);
-        expect(sumOfSquares(Array(6).fill(null), x)).toEqual(0);
         expect(sumOfSquares([2, 3, NaN, 5, 6, 7], x)).toEqual(5);
         expect(sumOfSquares(Array(6).fill(NaN), x)).toEqual(0);
     });

--- a/test/fit.test.ts
+++ b/test/fit.test.ts
@@ -18,5 +18,7 @@ describe("sumOfSquares", () => {
     it("allows missing values", () => {
         expect(sumOfSquares([2, 3, null, 5, 6, 7], x)).toEqual(5);
         expect(sumOfSquares(Array(6).fill(null), x)).toEqual(0);
+        expect(sumOfSquares([2, 3, NaN, 5, 6, 7], x)).toEqual(5);
+        expect(sumOfSquares(Array(6).fill(NaN), x)).toEqual(0);
     });
 })

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -151,4 +151,16 @@ describe("can fit a simple line", () => {
         const yFull = res.data.solutionAll(0, 6, 7);
         expect(yFull).toEqual([yFit]);
     });
+
+    it("Can fit a simple model with missing data", () => {
+        const time = [0, 1, 2, 3, 4, 5, 6];
+        const data = {time, value: time.map((t: number) => 1 + t * 4)}
+        data.value[3] = NaN;
+        const pars = {base: new Map<string, number>([["a", 0.5]]),
+                      vary: ["a"]};
+        const opt = wodinFit(models.User, data, pars, "x", {}, {});
+        const res = opt.run(100);
+        expect(res.converged).toBe(true);
+        expect(res.location[0]).toBeCloseTo(4);
+    });
 });


### PR DESCRIPTION
Allows fits to run with missing values. To match the changes in wodin, missing values are assumed to come in as NaN values within the numeric array.

Corresponding support in wodin is here: https://github.com/mrc-ide/wodin/pull/39 (though these PRs are actually independent)