### PR TITLE
Run a baseline before a fit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-export {wodinFit, wodinRun} from "./wodin";
+export {wodinFit, wodinFitBaseline, wodinRun} from "./wodin";
 export {PkgWrapper} from "./pkg";
 export {BaseType, base} from "./base";
-export {FitData, FitPars} from "./fit";
+export {FitData, FitPars, FitResult} from "./fit";
 export {
     InterpolatedSeries,
     InterpolatedSolution,

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -51,6 +51,8 @@ export function wodinRun(Model: OdinModelConstructable, pars: UserType,
  * * `solutionFit`: The solution to a just the modelled series being
  *    fit, as a single trace
  *
+ * See {@link FitResult}
+ *
  * @param Model The model constructor
  *
  * @param data The data to fit to; there will be one time and one data
@@ -76,4 +78,17 @@ export function wodinFit(Model: OdinModelConstructable, data: FitData,
     // everything variable is in fact a number)
     const start = pars.vary.map((nm: string) => pars.base.get(nm) as number);
     return new Simplex(target, start, controlFit);
+}
+
+/**
+ * Create a baseline for a fit, before the parameters to be varied in
+ * the fit are known. This runs an integration with the base
+ * parameters and returns everything that {@link wodinFit} would.
+ */
+export function wodinFitBaseline(Model: OdinModelConstructable, data: FitData,
+                                 pars: UserType, modelledSeries: string,
+                                 controlODE: Partial<DopriControlParam>) {
+    const parsFit = { base: pars, vary: [] };
+    const target = fitTarget(Model, data, parsFit, modelledSeries, controlODE);
+    return target([]);
 }

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,4 +1,4 @@
-import {wodinFit, wodinRun} from "../src/wodin";
+import { wodinFit, wodinFitBaseline, wodinRun } from "../src/wodin";
 import { grid } from "../src/util";
 import * as models from "./models";
 import {approxEqualArray} from "./helpers";
@@ -162,5 +162,29 @@ describe("can fit a simple line", () => {
         const res = opt.run(100);
         expect(res.converged).toBe(true);
         expect(res.location[0]).toBeCloseTo(4);
+    });
+});
+
+describe("can run a baseline", () => {
+    it("Can fit a simple model", () => {
+        const time = [0, 1, 2, 3, 4, 5, 6];
+        const data = {time, value: time.map((t: number) => 1 + t * 4)}
+        const pars = new Map<string, number>([["a", 0.5]]);
+        const modelledSeries = "x";
+        const controlODE = {};
+        const res = wodinFitBaseline(models.User, data, pars, modelledSeries,
+                                     controlODE);
+        // sum((1 + (1:6) * 0.5 - (1 + (1:6) * 4))^2)
+        expect(res.value).toBeCloseTo(1114.75);
+        expect(res.data.names).toEqual(["x"]);
+        expect(res.data.pars).toEqual(pars);
+
+        const yFit = res.data.solutionFit(0, 6, 7);
+        expect(yFit.name).toEqual("x");
+        expect(yFit.x).toEqual(time);
+        expect(yFit.y).toEqual([1, 1.5, 2, 2.5, 3, 3.5, 4]);
+
+        const yFull = res.data.solutionAll(0, 6, 7);
+        expect(yFull).toEqual([yFit]);
     });
 });


### PR DESCRIPTION
Adds a new function `wodinFitBaseline` which does the equivalent of the first point in the simplex. This can be called as we switch to the Fit tab, change fitted series or change parameters, and will return all the same data as the main fit result. Importantly, it provides the `InterpolatedSeries` for the single series in question and the sum of squares for the fit