### PR TITLE
Refactor wodin return type to be easier to work with

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/odinjs",
-            "version": "0.0.8",
+            "version": "0.0.9",
             "license": "MIT",
             "dependencies": {
                 "@reside-ic/interpolate": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -22,7 +22,7 @@ export class Batch {
     /** An array of solutions */
     public readonly solutions: InterpolatedSolution[];
 
-    private _extremes?: Extremes<Series[]>;
+    private _extremes?: Extremes<SeriesSet>;
 
     /** Construct a batch run, which will run the model many times
      *
@@ -57,14 +57,14 @@ export class Batch {
      * @param time The time; you can use -Infinity and Infinity to
      * represent the beginning and end of the solution
      */
-    public valueAtTime(time: number): Series[] {
-        const y = this.solutions.map(
+    public valueAtTime(time: number): SeriesSet {
+        const result = this.solutions.map(
             (s: InterpolatedSolution) => s(time, time, 1));
-        return y[0].map((_: any, idxSeries: number) => ({
-            name: y[0][idxSeries].name,
-            x: this.pars.values,
-            y: y.map((s: Series[]) => s[idxSeries].y[0]),
-        }));
+        const names = result[0].names;
+        const x = this.pars.values;
+        const y = result[0].names.map((_: any, idxSeries: number) =>
+                                      result.map((r: SeriesSet) => r.y[idxSeries][0]));
+        return {names, x, y};
     }
 
     /**
@@ -76,11 +76,11 @@ export class Batch {
      *   * "tMin": The time that each series reached its minimum
      *   * "tMax": The time that each series reached its maximum
      */
-    public extreme(name: keyof Extremes<Series[]>): Series[] {
+    public extreme(name: keyof Extremes<SeriesSet>): SeriesSet {
         return this.findExtremes()[name];
     }
 
-    private findExtremes(): Extremes<Series[]> {
+    private findExtremes() {
         if (this._extremes === undefined) {
             // Later we'll polish these off with a 1d optimiser from
             // ~50 points which will be likely faster and more
@@ -88,16 +88,20 @@ export class Batch {
             // dfoptim, then some additional work in findExtremes
             // (which will need to accept the solution object too).
             const n = 501;
-            const y = this.solutions.map(
+            const result = this.solutions.map(
                 (s: InterpolatedSolution) => s(this.tStart, this.tEnd, n));
-            const nms = y[0].map((x: Series) => x.name);
-            const extremes = loop(nms.length, (i: number) =>
-                                  y.map((s: Series[]) => findExtremes(s[i])));
+            const names = result[0].names;
+            const x = this.pars.values;
+
+            const extremes = loop(
+                names.length, (idxSeries: number) =>
+                    result.map((s: SeriesSet) => findExtremes(idxSeries, s)));
+
             this._extremes = {
-                tMax: extractExtremes("tMax", nms, this.pars.values, extremes),
-                tMin: extractExtremes("tMin", nms, this.pars.values, extremes),
-                yMax: extractExtremes("yMax", nms, this.pars.values, extremes),
-                yMin: extractExtremes("yMin", nms, this.pars.values, extremes),
+                tMax: extractExtremes("tMax", names, x, extremes),
+                tMin: extractExtremes("tMin", names, x, extremes),
+                yMax: extractExtremes("yMax", names, x, extremes),
+                yMin: extractExtremes("yMin", names, x, extremes),
             };
         }
         return this._extremes;
@@ -236,22 +240,22 @@ export interface Extremes<T> {
 // Later, we might do some polishing of these, which should make it
 // both faster and more accurate, but we'll need to pass in the
 // correct interpolating function too.
-function findExtremes(s: Series): Extremes<number> {
-    const idxMin = whichMin(s.y);
-    const idxMax = whichMax(s.y);
-    const tMin = s.x[idxMin];
-    const tMax = s.x[idxMax];
-    const yMin = s.y[idxMin];
-    const yMax = s.y[idxMax];
+function findExtremes(idxSeries: number, s: SeriesSet): Extremes<number> {
+    const t = s.x;
+    const y = s.y[idxSeries];
+    const idxMin = whichMin(y);
+    const idxMax = whichMax(y);
+    const tMin = t[idxMin];
+    const tMax = t[idxMax];
+    const yMin = y[idxMin];
+    const yMax = y[idxMax];
     return {tMax, tMin, yMax, yMin};
 }
 
 function extractExtremes(name: keyof Extremes<number>,
-                         names: string[], values: number[],
-                         extremes: Array<Array<Extremes<number>>>) {
-    return loop(names.length, (i: number) => ({
-        name: names[i],
-        x: values,
-        y: extremes[i].map((el: Extremes<number>) => el[name]),
-    }));
+                         names: string[],
+                         x: number[],
+                         extremes: Array<Array<Extremes<number>>>): SeriesSet {
+    const y = loop(names.length, (i: number) => extremes[i].map((el: Extremes<number>) => el[name]));
+    return { names, x, y };
 }

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,6 +1,10 @@
 import type { DopriControlParam } from "dopri";
 
-import type { InterpolatedSolution, OdinModelConstructable, Series } from "./model";
+import type {
+    InterpolatedSolution,
+    OdinModelConstructable,
+    SeriesSet,
+} from "./model";
 import { UserType } from "./user";
 import { grid, gridLog, loop, whichMax, whichMin } from "./util";
 import { wodinRun } from "./wodin";

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -3,10 +3,8 @@ import type { Result } from "dfoptim";
 import { base } from "./base";
 import type { OdinModelConstructable, Solution } from "./model";
 import {
-    InterpolatedSeries,
     interpolatedSolution,
     InterpolatedSolution,
-    partialInterpolatedSolution,
     runModel,
 } from "./model";
 import type {UserType} from "./user";
@@ -57,11 +55,7 @@ export interface FitResult extends Result {
         /** The solution of all series; an interpolating
          *   function as as would be returned by {@link wodinRun}
          */
-        solutionAll: InterpolatedSolution;
-        /** The solution to a just the modelled series being
-         *    fit, as a single trace
-         */
-        solutionFit: InterpolatedSeries;
+        solution: InterpolatedSolution;
     };
     /** The sum of squares for this set of parameters */
     value: number;
@@ -87,10 +81,8 @@ export function fitTarget(Model: OdinModelConstructable,
             data: {
                 names,
                 pars: p,
-                solutionAll: interpolatedSolution(
+                solution: interpolatedSolution(
                     solution, names, tStart, tEnd),
-                solutionFit: partialInterpolatedSolution(
-                    solution, modelledSeries, idxModel, tStart, tEnd),
             },
             /** Goodness of fit, the sum-of-squared differences
              * between the observed data and the modelled series

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,13 @@ export {PkgWrapper} from "./pkg";
 export {BaseType, base} from "./base";
 export {FitData, FitPars, FitResult} from "./fit";
 export {
-    InterpolatedSeries,
     InterpolatedSolution,
     OdinModelConstructable,
     OdinModel,
     OdinModelBase,
     OdinModelODE,
     OdinModelDDE,
-    Series,
+    SeriesSet,
     Solution,
 } from "./model";
 export {

--- a/src/model.ts
+++ b/src/model.ts
@@ -20,15 +20,39 @@ export type Solution = (t: number) => number[];
 export type FullSolution = (t: number[]) => number[][];
 
 /**
- * A series, compatible with the Plotly interface.
+ * We return a set of series from a few different places:
+ *
+ * * {@link wodinRun} returns the full set of series
+ * * {@link wodinFit} returns a single series with just the fit data
+ * * {@link batchRun} returns a number of full sets of series
+ *
+ * Later, when we get going with the stochastic interface, we'll need
+ * a slightly more flexible interface perhaps because we'll have a
+ * number of trajectories at once, and along with them summary
+ * statistics such as the mean or median.
+ *
+ * Using some key-value mapping will likely end up being a bit
+ * limiting eventually, because we have no easy place to store the
+ * metadata that we'll want (these 5 traces all correspond to variable
+ * 'x' with some parameter for example). So here, we'll use something
+ * deliberately simple but easy to extend. It does not try to closely
+ * match the plotly interface (wodin will take care of that instead).
+ *
+ * Later, we might want to swap the modelling of `y` for something
+ * slightly more flexible (either using a multidimensional array or
+ * allowing `y` to contain something more exotic per series).
  */
-export interface Series {
-    /** Name of the series */
-    name: string;
-    /** Values on the x axis, typically time */
-    x: number[];
-    /** Values on the y axis, typically a variable */
-    y: number[];
+export interface SeriesSet {
+    /** Names of elements in the series */
+    names: string[],
+    /** The domain that the series is available at, typically timea  */
+    x: number[],
+    /**
+     * The values of traces; will have length `names.length` and each
+     * element will have length `x.length`, so that `y[i][j]` is the
+     * `j`th time point of the `i`th series
+     */
+    y: number[][]
 }
 
 /**
@@ -46,26 +70,7 @@ export interface Series {
  * one, and points will be evenly spaced between `t0` and `t1`
  */
 export type InterpolatedSolution =
-    (t0: number, t1: number, nPoints: number) => Series[];
-
-/**
- * A single-series interpolated solution, part of the solution to a
- * system of differential equations (cf {@link InterpolatedSolution},
- * which represents the full soltion). Used internally by {@link
- * wodinFit}.
- *
- * @param t0 Start time to return the solution (cannot be less than
- * the originally used `tStart` - we will increase it to `tStart` in
- * that case)
- *
- * @param t1 End time to return the solution (cannot be more than the
- * originally used `tEnd` - we will reduce it to `tEnd` in that case)
- *
- * @param nPoints Number of points to return - must be at least
- * one, and points will be evenly spaced between `t0` and `t1`
- */
-export type InterpolatedSeries =
-    (t0: number, t1: number, nPoints: number) => Series;
+    (t0: number, t1: number, nPoints: number) => SeriesSet;
 
 /**
  * Constructor for an {@link OdinModel}
@@ -279,44 +284,13 @@ export function interpolatedSolution(solution: FullSolution,
                                      names: string[],
                                      tStart: number,
                                      tEnd: number): InterpolatedSolution {
-    return (t0: number, t1: number, nPoints: number) => {
+    return (t0: number, t1: number, nPoints: number): SeriesSet => {
         const t = grid(Math.max(tStart, t0), Math.min(tEnd, t1), nPoints);
-        const y = solution(t);
-        return y[0].map((_: any, i: number) => ({
-            name: names[i],
-            x: t,
-            y: y.map((row: number[]) => row[i]),
-        }));
-    };
-}
-
-/**
- * Conversion function for Dopri output into plotly input for a single
- * series, allowing efficient re-interpolation of subsets of the
- * graph. This is a single-trace version of {@link
- * interpolatedSolution} intended for use with {@link wodinFit} (via
- * {@link fitTarget}).
- *
- * @param solution The solution as returned from the solver
- *
- * @param name Name for the returned trace
- *
- * @param index The numeric index of the required trace within the
- * solution
- *
- * @param tStart Starting time for the integration
- *
- * @param tEnd End time for the integration
- */
-export function partialInterpolatedSolution(solution: FullSolution,
-                                            name: string,
-                                            index: number,
-                                            tStart: number,
-                                            tEnd: number): InterpolatedSeries {
-    return (t0: number, t1: number, nPoints: number) => {
-        const t = grid(Math.max(tStart, t0), Math.min(tEnd, t1), nPoints);
-        // TODO: we should support this in dopri directly
-        const y = solution(t).map((yt) => yt[index]);
-        return {name, x: t, y};
+        const values = solution(t);
+        // this is basically a transpose, pulling out every series in
+        // turn
+        const y = values[0].map(
+            (_: any, i: number) => values.map((row: number[]) => row[i]));
+        return { names, x: t, y };
     };
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -45,7 +45,7 @@ export type FullSolution = (t: number[]) => number[][];
 export interface SeriesSet {
     /** Names of elements in the series */
     names: string[];
-    /** The domain that the series is available at, typically timea  */
+    /** The domain that the series is available at, typically time  */
     x: number[];
     /**
      * The values of traces; will have length `names.length` and each

--- a/src/model.ts
+++ b/src/model.ts
@@ -44,15 +44,15 @@ export type FullSolution = (t: number[]) => number[][];
  */
 export interface SeriesSet {
     /** Names of elements in the series */
-    names: string[],
+    names: string[];
     /** The domain that the series is available at, typically timea  */
-    x: number[],
+    x: number[];
     /**
      * The values of traces; will have length `names.length` and each
      * element will have length `x.length`, so that `y[i][j]` is the
      * `j`th time point of the `i`th series
      */
-    y: number[][]
+    y: number[][];
 }
 
 /**

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -3,6 +3,6 @@ export function versions() {
     return {
         dfoptim: "0.0.5",
         dopri: "0.0.12",
-        odinjs: "0.0.8",
+        odinjs: "0.0.9",
     };
 }

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -101,10 +101,9 @@ describe("can extract from a batch result", () => {
         const tEnd = 10;
         const obj = batchRun(User, pars, tStart, tEnd, control);
         const res = obj.valueAtTime(tEnd);
-        expect(res.length).toBe(1); // just one series here
-        expect(res[0].name).toBe("x");
-        expect(res[0].x).toEqual(grid(0, 4, 5));
-        expect(approxEqualArray(res[0].y, [1, 11, 21, 31, 41])).toBe(true);
+        expect(res.names).toEqual(["x"]);
+        expect(res.x).toEqual(grid(0, 4, 5));
+        expect(approxEqualArray(res.y[0], [1, 11, 21, 31, 41])).toBe(true);
     });
 
     it("Extracts state at a particular time for multivariable models", () => {
@@ -115,15 +114,13 @@ describe("can extract from a batch result", () => {
         const tEnd = 10;
         const obj = batchRun(Output, pars, tStart, tEnd, control);
         const res = obj.valueAtTime(tEnd);
-        expect(res.length).toBe(2);
-        expect(res[0].name).toBe("x");
-        expect(res[1].name).toBe("y");
-        expect(res[0].x).toEqual(grid(0, 4, 5));
-        expect(approxEqualArray(res[0].y, [1, 11, 21, 31, 41])).toBe(true);
+        expect(res.names).toEqual(["x", "y"]);
+        expect(res.x).toEqual(grid(0, 4, 5));
+        expect(approxEqualArray(res.y[0], [1, 11, 21, 31, 41])).toBe(true);
+        expect(approxEqualArray(res.y[1], [2, 22, 42, 62, 82])).toBe(true);
         const e = obj.extreme("yMax");
-        expect(e.length).toBe(2);
-        expect(e[0].name).toBe("x");
-        expect(e[0].x).toEqual(grid(0, 4, 5));
-        expect(approxEqualArray(e[0].y, [1, 11, 21, 31, 41])).toBe(true);
+        expect(e.names).toEqual(["x", "y"]);
+        expect(e.x).toEqual(res.x);
+        expect(approxEqualArray(e.y[0], [1, 11, 21, 31, 41])).toBe(true);
     });
 });

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -86,7 +86,7 @@ describe("can run basic models", () => {
         const expectedT = grid(0, pi, 11);
         const expectedY = expectedT.map((t: number) => 1 - Math.cos(t));
         const y = solution(0, pi, 11);
-        expect(approxEqualArray(y[0].y, expectedY, 1e-4)).toBe(true);
+        expect(approxEqualArray(y.y[0], expectedY, 1e-4)).toBe(true);
     });
 
     it("runs a model with interpolated arrays", () => {
@@ -96,11 +96,11 @@ describe("can run basic models", () => {
         const control: any = {};
         const solution = wodinRun(models.InterpolateArray, user, 0, 3, control);
         const y = solution(0, 3, 51);
-        const t = y[0].x;
+        const t = y.x;
         const z1 = t.map((t: number) => t < 1 ? 0 : (t > 2 ? 1 : t - 1));
         const z2 = t.map((t: number) => t < 1 ? 0 : (t > 2 ? 2 : 2 * (t - 1)));
-        expect(approxEqualArray(y[0].y, z1, 6e-5)).toBe(true);
-        expect(approxEqualArray(y[1].y, z2, 6e-5)).toBe(true);
+        expect(approxEqualArray(y.y[0], z1, 6e-5)).toBe(true);
+        expect(approxEqualArray(y.y[1], z2, 6e-5)).toBe(true);
     });
 });
 

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -21,10 +21,10 @@ describe("can run basic models", () => {
         const y = solution(0, 10, 11);
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
-        expect(y.length).toEqual(1);
-        expect(y[0].name).toEqual("x");
-        expect(y[0].x).toEqual(expectedT);
-        expect(approxEqualArray(y[0].y, expectedX)).toBe(true);
+        expect(y.names).toEqual(["x"]);
+        expect(y.x).toEqual(expectedT);
+        expect(y.y.length).toBe(1);
+        expect(approxEqualArray(y.y[0], expectedX)).toBe(true);
     });
 
     it("runs model with output, with expected output", () => {
@@ -36,15 +36,11 @@ describe("can run basic models", () => {
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
         const expectedY = expectedX.map((x: number) => x * 2);
-        expect(y.length).toEqual(2);
 
-        expect(y[0].name).toEqual("x");
-        expect(y[0].x).toEqual(expectedT);
-        expect(approxEqualArray(y[0].y, expectedX)).toBe(true);
-
-        expect(y[1].name).toEqual("y");
-        expect(y[1].x).toEqual(expectedT);
-        expect(approxEqualArray(y[1].y, expectedY)).toBe(true);
+        expect(y.names).toEqual(["x", "y"]);
+        expect(y.x).toEqual(expectedT);
+        expect(approxEqualArray(y.y[0], expectedX)).toBe(true);
+        expect(approxEqualArray(y.y[1], expectedY)).toBe(true);
     });
 
     it("runs delay model without error", () => {
@@ -57,15 +53,10 @@ describe("can run basic models", () => {
         const expectedX = expectedT.map((t: number) => t + 1);
         const expectedY = expectedT.map((t: number) => Math.max(1, t - 1));
 
-        expect(y.length).toEqual(2);
-
-        expect(y[0].name).toEqual("x");
-        expect(y[0].x).toEqual(expectedT);
-        expect(approxEqualArray(y[0].y, expectedX)).toBe(true);
-
-        expect(y[1].name).toEqual("y");
-        expect(y[1].x).toEqual(expectedT);
-        expect(approxEqualArray(y[1].y, expectedY, 1e-3)).toBe(true);
+        expect(y.names).toEqual(["x", "y"]);
+        expect(y.x).toEqual(expectedT);
+        expect(approxEqualArray(y.y[0], expectedX)).toBe(true);
+        expect(approxEqualArray(y.y[1], expectedY, 1e-3)).toBe(true);
     });
 
     it("runs delay model without output without error", () => {
@@ -78,15 +69,10 @@ describe("can run basic models", () => {
         const expectedX = expectedT.map((t: number) => t + 1);
         const expectedY = [1, 2, 3, 4.5, 7, 10.5, 15, 20.5, 27, 34.5, 43];
 
-        expect(y.length).toEqual(2);
-
-        expect(y[0].name).toEqual("x");
-        expect(y[0].x).toEqual(expectedT);
-        expect(approxEqualArray(y[0].y, expectedX)).toBe(true);
-
-        expect(y[1].name).toEqual("y");
-        expect(y[1].x).toEqual(expectedT);
-        expect(approxEqualArray(y[1].y, expectedY, 1e-3)).toBe(true);
+        expect(y.names).toEqual(["x", "y"]);
+        expect(y.x).toEqual(expectedT);
+        expect(approxEqualArray(y.y[0], expectedX)).toBe(true);
+        expect(approxEqualArray(y.y[1], expectedY, 1e-3)).toBe(true);
     });
 
     it("runs a model with interpolation", () => {
@@ -148,10 +134,9 @@ describe("can set user", () => {
         const y = solution(0, 10, 11);
         const expectedX = grid(0, 10, 11);
         const expectedY = expectedX.map((t: number) => t * 2 + 1);
-        expect(y.length).toEqual(1);
-        expect(y[0].name).toEqual("x");
-        expect(y[0].x).toEqual(expectedX);
-        expect(approxEqualArray(y[0].y, expectedY)).toBe(true);
+        expect(y.names).toEqual(["x"]);
+        expect(y.x).toEqual(expectedX);
+        expect(approxEqualArray(y.y[0], expectedY)).toBe(true);
     })
 });
 
@@ -173,13 +158,10 @@ describe("can fit a simple line", () => {
         expect(res.value).toBeCloseTo(0);
         expect(res.data.pars.get("a")).toEqual(res.location[0]);
 
-        const yFit = res.data.solutionFit(0, 6, 7);
-        expect(yFit.name).toEqual("x");
+        const yFit = res.data.solution(0, 6, 7);
+        expect(yFit.names).toEqual(["x"]);
         expect(yFit.x).toEqual(time);
-        expect(approxEqualArray(yFit.y, data.value)).toBe(true);
-
-        const yFull = res.data.solutionAll(0, 6, 7);
-        expect(yFull).toEqual([yFit]);
+        expect(approxEqualArray(yFit.y[0], data.value)).toBe(true);
     });
 
     it("Can fit a simple model with missing data", () => {
@@ -209,12 +191,9 @@ describe("can run a baseline", () => {
         expect(res.data.names).toEqual(["x"]);
         expect(res.data.pars).toEqual(pars);
 
-        const yFit = res.data.solutionFit(0, 6, 7);
-        expect(yFit.name).toEqual("x");
+        const yFit = res.data.solution(0, 6, 7);
+        expect(yFit.names).toEqual(["x"]);
         expect(yFit.x).toEqual(time);
-        expect(yFit.y).toEqual([1, 1.5, 2, 2.5, 3, 3.5, 4]);
-
-        const yFull = res.data.solutionAll(0, 6, 7);
-        expect(yFull).toEqual([yFit]);
+        expect(yFit.y[0]).toEqual([1, 1.5, 2, 2.5, 3, 3.5, 4]);
     });
 });


### PR DESCRIPTION
This PR refactors the return type - now we won't have a different type for the fit and run, and that type should be easier to work with.

Previously we used an array of objects that looked pretty close to what plotly wanted. Now we provide a single object with information about names, the shared x values and an array-of-arrays of y values. The hope here is that this will allow some extensibility in future, though we might end up generalising what goes in the y array a bit.