### PR TITLE
Save end time into fit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -45,6 +45,8 @@ export interface FitPars {
  */
 export interface FitResult extends Result {
     data: {
+        /** The end time of the integration */
+        endTime: number;
         /** The names of all traces returned by the model */
         names: string[];
         /** The full model parameters, as a Map (i.e., suitable to
@@ -79,6 +81,7 @@ export function fitTarget(Model: OdinModelConstructable,
         return {
             /** Additional data alongside the goodness of fit, see above */
             data: {
+                endTime: tEnd,
                 names,
                 pars: p,
                 solution: interpolatedSolution(

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -23,7 +23,7 @@ import type { UserType } from "./user";
  */
 export function wodinRun(Model: OdinModelConstructable, pars: UserType,
                          tStart: number, tEnd: number,
-                         control: Partial<DopriControlParam> = {}) {
+                         control: Partial<DopriControlParam>) {
     const model = new Model(base, pars, "error");
     const y0 = null;
     const solution = runModel(model, y0, tStart, tEnd, control).solution;

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -23,7 +23,7 @@ import type { UserType } from "./user";
  */
 export function wodinRun(Model: OdinModelConstructable, pars: UserType,
                          tStart: number, tEnd: number,
-                         control: Partial<DopriControlParam>) {
+                         control: Partial<DopriControlParam> = {}) {
     const model = new Model(base, pars, "error");
     const y0 = null;
     const solution = runModel(model, y0, tStart, tEnd, control).solution;

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -157,6 +157,7 @@ describe("can fit a simple line", () => {
         expect(res.location[0]).toBeCloseTo(4);
         expect(res.value).toBeCloseTo(0);
         expect(res.data.pars.get("a")).toEqual(res.location[0]);
+        expect(res.data.endTime).toEqual(6);
 
         const yFit = res.data.solution(0, 6, 7);
         expect(yFit.names).toEqual(["x"]);
@@ -190,6 +191,7 @@ describe("can run a baseline", () => {
         expect(res.value).toBeCloseTo(1114.75);
         expect(res.data.names).toEqual(["x"]);
         expect(res.data.pars).toEqual(pars);
+        expect(res.data.endTime).toEqual(6);
 
         const yFit = res.data.solution(0, 6, 7);
         expect(yFit.names).toEqual(["x"]);


### PR DESCRIPTION
No ticket for this, but something that we need to avoid duplicating some logic. This adds the end time into the "data" returned by the solution