### PR TITLE
Remove use of Map

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -210,13 +210,13 @@ export function batchParsDisplace(base: UserType, name: string, count: number,
 }
 
 export function updatePars(base: UserType, name: string, value: number) {
-    const ret = new Map(base);
-    ret.set(name, value);
+    const ret = { ...base };
+    ret[name] = value;
     return ret;
 }
 
 function getParameterValueAsNumber(pars: UserType, name: string): number {
-    const value = pars.get(name);
+    const value = pars[name];
     if (value === undefined) {
         throw Error(`Expected a value for '${name}'`);
     }

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -49,8 +49,9 @@ export interface FitResult extends Result {
         endTime: number;
         /** The names of all traces returned by the model */
         names: string[];
-        /** The full model parameters, as a Map (i.e., suitable to
-         *   pass back into an {@link OdinModelConstructable} object or {@link
+        /** The full model parameters, as an object mapping strings to
+         *   {@link UserValue} (i.e., suitable to pass back into an
+         *   {@link OdinModelConstructable} object or {@link
          *   wodinRun})
          */
         pars: UserType;
@@ -96,9 +97,9 @@ export function fitTarget(Model: OdinModelConstructable,
 }
 
 export function updatePars(pars: FitPars, theta: number[]) {
-    const ret = new Map(pars.base);
+    const ret = { ...pars.base };
     for (let i = 0; i < pars.vary.length; ++i) {
-        ret.set(pars.vary[i], theta[i]);
+        ret[pars.vary[i]] = theta[i];
     }
     return ret;
 }

--- a/src/user.ts
+++ b/src/user.ts
@@ -34,7 +34,7 @@ export type UserValue = number | number[] | UserTensor;
 /**
  * A key-value map of user-provided parameters
  */
-export type UserType = Map<string, UserValue>;
+export type UserType = { [k: string]: UserValue };
 
 /**
  * The data type corresponding to odin's internal data structures - a
@@ -63,7 +63,7 @@ export function checkUser(pars: UserType, allowed: string[],
         return;
     }
     const err = [];
-    for (const k of pars.keys()) {
+    for (const k of Object.keys(pars)) {
         if (!allowed.includes(k)) {
             err.push(k);
         }
@@ -109,7 +109,7 @@ export function setUserScalar(pars: UserType, name: string,
                               internal: InternalStorage,
                               defaultValue: number | null, min: number,
                               max: number, isInteger: boolean) {
-    const value = pars.get(name);
+    const value = pars[name];
     if (value === undefined) {
         if (internal[name] !== undefined) {
             return;
@@ -156,7 +156,7 @@ export function setUserArrayFixed(pars: UserType, name: string,
                                   min: number,
                                   max: number,
                                   isInteger: boolean) {
-    let value = pars.get(name);
+    let value = pars[name];
     if (value === undefined) {
         if (internal[name] !== undefined) {
             return;
@@ -213,7 +213,7 @@ export function setUserArrayVariable(pars: UserType, name: string,
                                      min: number,
                                      max: number,
                                      isInteger: boolean) {
-    let value = pars.get(name);
+    let value = pars[name];
     if (value === undefined) {
         if (internal[name] !== undefined) {
             return;

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -43,9 +43,9 @@ export function wodinRun(Model: OdinModelConstructable, pars: UserType,
  * interpolated solutions available via an object containing:
  *
  * * `names`: the names of all traces returned by the model
- * * `pars`: The full model parameters, as a Map (i.e., suitable to
- *   pass back into an {@link OdinModelConstructable} object or {@link
- *   wodinRun})
+ * * `pars`: The full model parameters, as an object mapping strings
+ *   to {@link UserValue} (i.e., suitable to pass back into an {@link
+ *   OdinModelConstructable} object or {@link wodinRun})
  * * `solutionAll`: The solution of all series; an interpolating
  *   function as as would be returned by {@link wodinRun}
  * * `solutionFit`: The solution to a just the modelled series being
@@ -76,7 +76,7 @@ export function wodinFit(Model: OdinModelConstructable, data: FitData,
     const target = fitTarget(Model, data, pars, modelledSeries, controlODE);
     // TODO: require that we have starting points here (i.e., that
     // everything variable is in fact a number)
-    const start = pars.vary.map((nm: string) => pars.base.get(nm) as number);
+    const start = pars.vary.map((nm: string) => pars.base[nm] as number);
     return new Simplex(target, start, controlFit);
 }
 

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -7,7 +7,7 @@ import { Output, User } from "./models";
 
 describe("Can generate sensible sets of parameters", () => {
     it("Generates a simple sequence", () => {
-        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const user = { a: 1, b: 2 };
         const res = batchParsRange(user, "a", 5, false, 0, 2);
         expect(res.base).toBe(user);
         expect(res.name).toBe("a");
@@ -15,7 +15,7 @@ describe("Can generate sensible sets of parameters", () => {
     });
 
     it("Generates a logarithmic sequence", () => {
-        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const user = { a: 1, b: 2 };
         const res = batchParsRange(user, "a", 5, true, 0.5, 1.5);
         expect(res.base).toBe(user);
         expect(res.name).toBe("a");
@@ -23,7 +23,7 @@ describe("Can generate sensible sets of parameters", () => {
     });
 
     it("Generates a displaced sequence", () => {
-        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const user = { a: 1, b: 2 };
         const res = batchParsDisplace(user, "b", 5, false, 50);
         expect(res.base).toBe(user);
         expect(res.name).toBe("b");
@@ -31,7 +31,7 @@ describe("Can generate sensible sets of parameters", () => {
     });
 
     it("Requires that central values lie within the requested range", () => {
-        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const user = { a: 1, b: 2 };
         expect(() => batchParsRange(user, "a", 5, false, 3, 4))
             .toThrow("Expected lower bound to be no greater than 1");
         expect(() => batchParsRange(user, "a", 5, false, -2, -1))
@@ -41,40 +41,40 @@ describe("Can generate sensible sets of parameters", () => {
     });
 
     it("Requires that we have at least two points in the range", () => {
-        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const user = { a: 1, b: 2 };
         expect(() => batchParsRange(user, "a", 1, false, 0, 2))
             .toThrow("Must include at least 2 traces in the batch");
     });
 
     it("Requires that the updated parameter exists", () => {
-        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const user = { a: 1, b: 2 };
         expect(() => batchParsRange(user, "c", 5, false, 0, 2))
             .toThrow("Expected a value for 'c'");
     });
 
     it("Requires a scalar for the updated parameter", () => {
-        const user = new Map<string, number | number[]>([["a", [1, 2]]]);
+        const user = { "a": [1, 2] };
         expect(() => batchParsRange(user, "a", 5, false, 0, 2))
             .toThrow("Expected a number for 'a'");
     });
 
     it("Requires that log scaled values have strictly positive lower bound", () => {
-        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const user = { a: 1, b: 2 };
         expect(() => batchParsRange(user, "a", 5, true, 0, 1.5))
             .toThrow("Lower bound must be greater than 0 for logarithmic scale");
     });
 
     it("Updates parameter values correctly", () => {
-        const user = new Map<string, number>([["a", 1], ["b", 2]]);
+        const user = { a: 1, b: 2 };
         const p = updatePars(user, "a", 3);
-        expect(p.get("a")).toBe(3);
-        expect(p.get("b")).toBe(2);
+        expect(p["a"]).toBe(3);
+        expect(p["b"]).toBe(2);
     });
 });
 
 describe("run sensitivity", () => {
     it("runs without error", () => {
-        const user = new Map<string, number>([["a", 2]]);
+        const user = { a: 2 };
         const pars = batchParsRange(user, "a", 5, false, 0, 4);
         const control = {};
         const tStart = 0;
@@ -82,10 +82,8 @@ describe("run sensitivity", () => {
         const res = batchRun(User, pars, tStart, tEnd, control);
 
         const central = wodinRun(User, user, tStart, tEnd, control);
-        const lower = wodinRun(User, new Map<string, number>([["a", 0]]),
-                               tStart, tEnd, control);
-        const upper = wodinRun(User, new Map<string, number>([["a", 4]]),
-                               tStart, tEnd, control);
+        const lower = wodinRun(User, { a: 0 }, tStart, tEnd, control);
+        const upper = wodinRun(User, { a: 4 }, tStart, tEnd, control);
         const n = 11;
         expect(res.solutions[2](tStart, tEnd, n))
             .toEqual(central(tStart, tEnd, n));
@@ -100,7 +98,7 @@ describe("can extract from a batch result", () => {
     // TODO: we need a model with both parameters and multiple traces
     // here to confirm this is correct.
     it("Extracts state at a particular time", () => {
-        const user = new Map<string, number>([["a", 2]]);
+        const user = { a: 2 };
         const pars = batchParsRange(user, "a", 5, false, 0, 4);
         const control = {};
         const tStart = 0;
@@ -113,7 +111,7 @@ describe("can extract from a batch result", () => {
     });
 
     it("Extracts state at a particular time for multivariable models", () => {
-        const user = new Map<string, number>([["a", 2]]);
+        const user = { a: 2 };
         const pars = batchParsRange(user, "a", 5, false, 0, 4);
         const control = {};
         const tStart = 0;

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -53,7 +53,7 @@ describe("Can generate sensible sets of parameters", () => {
     });
 
     it("Requires a scalar for the updated parameter", () => {
-        const user = { "a": [1, 2] };
+        const user = { a: [1, 2] };
         expect(() => batchParsRange(user, "a", 5, false, 0, 2))
             .toThrow("Expected a number for 'a'");
     });

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -5,7 +5,7 @@ import {approxEqualArray} from "./helpers";
 
 describe("wrapper", () => {
     it("Can create a simple wrapped model", () => {
-        const user = new Map<string, number>();
+        const user = {};
         const control : any = {};
         const mod = new PkgWrapper(models.Minimal, user, "error");
 
@@ -21,14 +21,14 @@ describe("wrapper", () => {
     });
 
     it("Can run the rhs with output", () => {
-        const user = new Map<string, number>([["a", 1]]);
+        const user = { "a": 1 };
         const control : any = {};
         const mod = new PkgWrapper(models.Output, user, "error");
         expect(mod.rhs(0, [1])).toEqual({"output": [2], "state": [1]});
     });
 
     it("Refuses to run rhs for dde models", () => {
-        const user = new Map<string, number>();
+        const user = {};
         const control : any = {};
         const mod = new PkgWrapper(models.Delay, user, "error");
         expect(() => mod.rhs(0, [0])).toThrow(
@@ -36,7 +36,7 @@ describe("wrapper", () => {
     });
 
     it("Can override the initial conditions", () => {
-        const user = new Map<string, number>();
+        const user = {};
         const control : any = {};
         const mod = new PkgWrapper(models.Minimal, user, "error");
 
@@ -48,16 +48,16 @@ describe("wrapper", () => {
     })
 
     it("Can set user variables", () => {
-        const user = new Map<string, number>([["a", 1]]);
+        const user = { "a": 1 };
         const control: any = {};
         const mod = new PkgWrapper(models.User, user, "error");
         const t = 0;
         const y = [0];
         expect(mod.rhs(t, y).state).toEqual([1]);
-        user.set("a", 2);
+        user["a"] = 2;
         mod.setUser(user, "error");
         expect(mod.rhs(t, y).state).toEqual([2]);
-        mod.setUser(new Map<string, number>(), "error");
+        mod.setUser({}, "error");
         expect(mod.rhs(t, y).state).toEqual([2]);
     });
 });

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -21,7 +21,7 @@ describe("wrapper", () => {
     });
 
     it("Can run the rhs with output", () => {
-        const user = { "a": 1 };
+        const user = { a: 1 };
         const control : any = {};
         const mod = new PkgWrapper(models.Output, user, "error");
         expect(mod.rhs(0, [1])).toEqual({"output": [2], "state": [1]});
@@ -48,7 +48,7 @@ describe("wrapper", () => {
     })
 
     it("Can set user variables", () => {
-        const user = { "a": 1 };
+        const user = { a: 1 };
         const control: any = {};
         const mod = new PkgWrapper(models.User, user, "error");
         const t = 0;

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -188,11 +188,11 @@ describe("setUserArrayFixed", () => {
 
 describe("setUserArrayVariable", () => {
     const pars = {
-        "a": 1,
-        "b": [1, 2, 3],
-        "c": {data: [1, 2, 3], dim: [3]},
-        "d": {data: [1, 2, 3, 4, 5, 6], dim: [2, 3]},
-        "e": {data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dim: [2, 3, 2]},
+        a: 1,
+        b: [1, 2, 3],
+        c: {data: [1, 2, 3], dim: [3]},
+        d: {data: [1, 2, 3, 4, 5, 6], dim: [2, 3]},
+        e: {data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dim: [2, 3, 2]},
     };
     it("Can fetch a variable and save sizes", () => {
         const size = [0, 0, 0];

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -1,7 +1,7 @@
 import {InternalStorage, UserTensor, UserValue, checkUser, setUserScalar, setUserArrayFixed, setUserArrayVariable} from "../src/user";
 
 describe("checkUser", () => {
-    const pars = new Map<string, UserValue>([["a", 1], ["b", 2], ["c", 3]]);
+    const pars = { a: 1, b: 2, c: 3 };
     it("does no checking if ignored", () => {
         checkUser(pars, [], "ignore");
     });
@@ -41,7 +41,7 @@ describe("checkUser", () => {
 });
 
 describe("setUserScalar", () => {
-    const pars = new Map<string, UserValue>([["a", 1], ["b", 2.5], ["c", 3]]);
+    const pars = { a: 1, b: 2.5, c: 3 };
     it("Can retrieve a user value", () => {
         const internal = {} as InternalStorage;
         setUserScalar(pars, "a", internal, null, -Infinity, Infinity, false);
@@ -74,7 +74,7 @@ describe("setUserScalar", () => {
     });
 
     it("Errors if given something other than a number", () => {
-        const pars = new Map<string, UserValue>([["a", [1, 2, 3]]]);
+        const pars = { a: [1, 2, 3] };
         const internal = {} as InternalStorage;
         expect(() => setUserScalar(
             pars, "a", internal, null, -Infinity, Infinity, false))
@@ -83,13 +83,13 @@ describe("setUserScalar", () => {
 });
 
 describe("setUserArrayFixed", () => {
-    const pars = new Map<string, UserValue>([
-        ["a", 1],
-        ["b", [1, 2, 3]],
-        ["c", {data: [1, 2, 3], dim: [3]}],
-        ["d", {data: [1, 2, 3, 4, 5, 6], dim: [2, 3]}],
-        ["e", {data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dim: [2, 3, 2]}]
-    ]);
+    const pars = {
+        a: 1,
+        b: [1, 2, 3],
+        c: {data: [1, 2, 3], dim: [3]},
+        d: {data: [1, 2, 3, 4, 5, 6], dim: [2, 3]},
+        e: {data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dim: [2, 3, 2]}
+    };
     it("Can retrieve a user array from a scalar", () => {
         const internal = {} as InternalStorage;
         setUserArrayFixed(pars, "a", internal, [1, 1],
@@ -162,9 +162,7 @@ describe("setUserArrayFixed", () => {
 
     it("Can prevent missing values", () => {
         const internal = {} as InternalStorage;
-        const pars = new Map<string, UserValue>([
-            ["x", {data: [1, 2, null as any], dim: [3]}]
-        ]);
+        const pars = { "x": {data: [1, 2, null as any], dim: [3]} };
         expect(() => setUserArrayFixed(
             pars, "x", internal, [3, 3], -Infinity, Infinity, false))
             .toThrow("'x' must not contain any NA values");
@@ -172,9 +170,9 @@ describe("setUserArrayFixed", () => {
 
     it("Errors if given non-numeric data", () => {
         const internal = {} as InternalStorage;
-        const pars = new Map<string, UserValue>([
-            ["x", {data: [1, 2, "three" as any], dim: [3]}]
-        ]);
+        const pars = {
+            "x": { data: [1, 2, "three" as any], dim: [3] }
+        };
         expect(() => setUserArrayFixed(
             pars, "x", internal, [3, 3], -Infinity, Infinity, false))
             .toThrow("Expected a number for 'x'");
@@ -189,13 +187,13 @@ describe("setUserArrayFixed", () => {
 });
 
 describe("setUserArrayVariable", () => {
-    const pars = new Map<string, UserValue>([
-        ["a", 1],
-        ["b", [1, 2, 3]],
-        ["c", {data: [1, 2, 3], dim: [3]}],
-        ["d", {data: [1, 2, 3, 4, 5, 6], dim: [2, 3]}],
-        ["e", {data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dim: [2, 3, 2]}]
-    ]);
+    const pars = {
+        "a": 1,
+        "b": [1, 2, 3],
+        "c": {data: [1, 2, 3], dim: [3]},
+        "d": {data: [1, 2, 3, 4, 5, 6], dim: [2, 3]},
+        "e": {data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dim: [2, 3, 2]},
+    };
     it("Can fetch a variable and save sizes", () => {
         const size = [0, 0, 0];
         const internal = {} as InternalStorage;

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -14,7 +14,7 @@ describe("grid", () => {
 
 describe("can run basic models", () => {
     it("runs minimal model with expected output", () => {
-        const user = new Map<string, number>();
+        const user = {};
         const control : any = {};
         const solution = wodinRun(models.Minimal, user, 0, 10, control);
 
@@ -28,7 +28,7 @@ describe("can run basic models", () => {
     });
 
     it("runs model with output, with expected output", () => {
-        const user = new Map<string, number>([["a", 1]]);
+        const user = { "a": 1 };
         const control : any = {};
         const solution = wodinRun(models.Output, user, 0, 10, control);
 
@@ -44,7 +44,7 @@ describe("can run basic models", () => {
     });
 
     it("runs delay model without error", () => {
-        const user = new Map<string, number>();
+        const user = {};
         const control : any = {};
         const solution = wodinRun(models.Delay, user, 0, 10, control);
         const y = solution(0, 10, 11);
@@ -60,7 +60,7 @@ describe("can run basic models", () => {
     });
 
     it("runs delay model without output without error", () => {
-        const user = new Map<string, number>();
+        const user = {};
         const control : any = {};
         const solution = wodinRun(models.DelayNoOutput, user, 0, 10, control);
         const y = solution(0, 10, 11);
@@ -79,7 +79,7 @@ describe("can run basic models", () => {
         const pi = Math.PI;
         const tp = grid(0, pi, 31);
         const zp = tp.map((t: number) => Math.sin(t));
-        const user = new Map<string, number | number[]>([["tp", tp], ["zp", zp]]);
+        const user = { tp, zp };
         const control : any = {};
         const solution = wodinRun(models.InterpolateSpline, user, 0, pi, control);
 
@@ -92,7 +92,7 @@ describe("can run basic models", () => {
     it("runs a model with interpolated arrays", () => {
         const tp = [0, 1, 2];
         const zp: UserTensor = {data: [0, 1, 0, 0, 2, 0], dim: [3, 2]};
-        const user = new Map<string, UserValue>([["tp", tp], ["zp", zp]]);
+        const user = { tp, zp };
         const control: any = {};
         const solution = wodinRun(models.InterpolateArray, user, 0, 3, control);
         const y = solution(0, 3, 51);
@@ -106,8 +106,8 @@ describe("can run basic models", () => {
 
 describe("can set user", () => {
     it("Agrees with mininal model", () => {
-        const pars1 = new Map<string, number>();
-        const pars2 = new Map<string, number>([["a", 1]]);
+        const pars1 = {};
+        const pars2 = { "a": 1 };
         const control : any = {};
         const solution1 = wodinRun(models.Minimal, pars1, 0, 10, control);
         const solution2 = wodinRun(models.User, pars2, 0, 10, control);
@@ -117,8 +117,8 @@ describe("can set user", () => {
     });
 
     it("Can pick up default values", () => {
-        const pars1 = new Map<string, number>();
-        const pars2 = new Map<string, number>([["a", 1]]);
+        const pars1 = {};
+        const pars2 = { "a": 1 };
         const control : any = {};
         const solution1 = wodinRun(models.User, pars1, 0, 10, control);
         const solution2 = wodinRun(models.User, pars2, 0, 10, control);
@@ -128,7 +128,7 @@ describe("can set user", () => {
     });
 
     it("Varies by changing parameters", () => {
-        const pars = new Map<string, number>([["a", 2]]);
+        const pars = { "a": 2 };
         const control : any = {};
         const solution = wodinRun(models.User, pars, 0, 10, control);
         const y = solution(0, 10, 11);
@@ -144,7 +144,7 @@ describe("can fit a simple line", () => {
     it("Can fit a simple model", () => {
         const time = [0, 1, 2, 3, 4, 5, 6];
         const data = {time, value: time.map((t: number) => 1 + t * 4)}
-        const pars = {base: new Map<string, number>([["a", 0.5]]),
+        const pars = {base: { a: 0.5 },
                       vary: ["a"]};
         const modelledSeries = "x";
         const controlODE = {};
@@ -156,7 +156,7 @@ describe("can fit a simple line", () => {
         expect(res.converged).toBe(true);
         expect(res.location[0]).toBeCloseTo(4);
         expect(res.value).toBeCloseTo(0);
-        expect(res.data.pars.get("a")).toEqual(res.location[0]);
+        expect(res.data.pars["a"]).toEqual(res.location[0]);
         expect(res.data.endTime).toEqual(6);
 
         const yFit = res.data.solution(0, 6, 7);
@@ -169,7 +169,7 @@ describe("can fit a simple line", () => {
         const time = [0, 1, 2, 3, 4, 5, 6];
         const data = {time, value: time.map((t: number) => 1 + t * 4)}
         data.value[3] = NaN;
-        const pars = {base: new Map<string, number>([["a", 0.5]]),
+        const pars = {base: { a: 0.5 },
                       vary: ["a"]};
         const opt = wodinFit(models.User, data, pars, "x", {}, {});
         const res = opt.run(100);
@@ -182,7 +182,7 @@ describe("can run a baseline", () => {
     it("Can fit a simple model", () => {
         const time = [0, 1, 2, 3, 4, 5, 6];
         const data = {time, value: time.map((t: number) => 1 + t * 4)}
-        const pars = new Map<string, number>([["a", 0.5]]);
+        const pars = { "a": 0.5 };
         const modelledSeries = "x";
         const controlODE = {};
         const res = wodinFitBaseline(models.User, data, pars, modelledSeries,

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,8 @@
     "rules": {
         "interface-name": [true, "never-prefix"],
         "variable-name": [true, "allow-leading-underscore", "allow-pascal-case"],
-        "no-console": false
+        "no-console": false,
+        "interface-over-type-literal": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
This PR removes use of Map from within the odin-js code, using the same approach as the Dict util type in wodin:

```
export type UserType = { [k: string]: UserValue };
```

The lint rule is to stop us making an interface for this type, seems best to just have it exactly the same as wodin? Eventually I'll move this over to match the eslint config used elsewhere

Eventually ends up as https://github.com/mrc-ide/wodin/pull/61 via https://github.com/mrc-ide/odin/pull/270 and https://github.com/mrc-ide/odin.api/pull/10