### PR TITLE
New function for computing sum of squares from existing solution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.10",
+    "version": "0.0.14",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/odinjs",
-            "version": "0.0.10",
+            "version": "0.0.14",
             "license": "MIT",
             "dependencies": {
                 "@reside-ic/interpolate": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,10 +1,8 @@
 import type { DopriControlParam } from "dopri";
 
-import type {
-    InterpolatedSolution,
-    OdinModelConstructable,
-    SeriesSet,
-} from "./model";
+import type { OdinModelConstructable } from "./model";
+import type { InterpolatedSolution, SeriesSet } from "./solution";
+
 import { UserType } from "./user";
 import { grid, gridLog, loop, whichMax, whichMin } from "./util";
 import { wodinRun } from "./wodin";

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -57,7 +57,7 @@ export class Batch {
      */
     public valueAtTime(time: number): SeriesSet {
         const result = this.solutions.map(
-            (s: InterpolatedSolution) => s(time, time, 1));
+            (s: InterpolatedSolution) => s({ mode: "given", times: [time] }));
         const names = result[0].names;
         const x = this.pars.values;
         const y = result[0].names.map((_: any, idxSeries: number) =>
@@ -86,8 +86,13 @@ export class Batch {
             // dfoptim, then some additional work in findExtremes
             // (which will need to accept the solution object too).
             const n = 501;
-            const result = this.solutions.map(
-                (s: InterpolatedSolution) => s(this.tStart, this.tEnd, n));
+            const times = {
+                mode: "grid",
+                nPoints: n,
+                tEnd: this.tEnd,
+                tStart: this.tStart,
+            } as const;
+            const result = this.solutions.map((s: InterpolatedSolution) => s(times));
             const names = result[0].names;
             const x = this.pars.values;
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,8 +1,7 @@
 import type { DopriControlParam } from "dopri";
 
 import type { OdinModelConstructable } from "./model";
-import type { InterpolatedSolution, SeriesSet } from "./solution";
-
+import { InterpolatedSolution, SeriesSet, TimeMode } from "./solution";
 import { UserType } from "./user";
 import { grid, gridLog, loop, whichMax, whichMin } from "./util";
 import { wodinRun } from "./wodin";
@@ -57,7 +56,7 @@ export class Batch {
      */
     public valueAtTime(time: number): SeriesSet {
         const result = this.solutions.map(
-            (s: InterpolatedSolution) => s({ mode: "given", times: [time] }));
+            (s: InterpolatedSolution) => s({ mode: TimeMode.Given, times: [time] }));
         const names = result[0].names;
         const x = this.pars.values;
         const y = result[0].names.map((_: any, idxSeries: number) =>
@@ -87,7 +86,7 @@ export class Batch {
             // (which will need to accept the solution object too).
             const n = 501;
             const times = {
-                mode: "grid",
+                mode: TimeMode.Grid,
                 nPoints: n,
                 tEnd: this.tEnd,
                 tStart: this.tStart,

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -1,12 +1,10 @@
 import type { Result } from "dfoptim";
 
 import { base } from "./base";
-import type { OdinModelConstructable, Solution } from "./model";
-import {
-    interpolatedSolution,
-    InterpolatedSolution,
-    runModel,
-} from "./model";
+import type { FullSolution, OdinModelConstructable, Solution } from "./model";
+import { runModel } from "./model";
+import { interpolatedSolution } from "./solution";
+import type { InterpolatedSolution, SeriesSet } from "./solution";
 import type {UserType} from "./user";
 
 /** Interface for data to fit an odin model to; every data set has two

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,17 @@ export {PkgWrapper} from "./pkg";
 export {BaseType, base} from "./base";
 export {FitData, FitPars, FitResult} from "./fit";
 export {
-    InterpolatedSolution,
     OdinModelConstructable,
     OdinModel,
     OdinModelBase,
     OdinModelODE,
     OdinModelDDE,
-    SeriesSet,
     Solution,
 } from "./model";
+export {
+    InterpolatedSolution,
+    SeriesSet,
+} from "./solution";
 export {
     Batch,
     BatchPars,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export {wodinFit, wodinFitBaseline, wodinRun} from "./wodin";
+export {wodinFit, wodinFitValue, wodinRun} from "./wodin";
 export {PkgWrapper} from "./pkg";
 export {BaseType, base} from "./base";
 export {FitData, FitPars, FitResult} from "./fit";

--- a/src/model.ts
+++ b/src/model.ts
@@ -4,7 +4,6 @@ import type { DopriControlParam } from "dopri";
 import { base, BaseType } from "./base";
 import { interpolateCheckT } from "./interpolate";
 import { InternalStorage, UserType } from "./user";
-import { grid } from "./util";
 
 /** Interpolated solution to the system of differential equations
  *
@@ -18,59 +17,6 @@ export type Solution = (t: number) => number[];
  *  @param t The time to look up the solution at
  */
 export type FullSolution = (t: number[]) => number[][];
-
-/**
- * We return a set of series from a few different places:
- *
- * * {@link wodinRun} returns the full set of series
- * * {@link wodinFit} returns a single series with just the fit data
- * * {@link batchRun} returns a number of full sets of series
- *
- * Later, when we get going with the stochastic interface, we'll need
- * a slightly more flexible interface perhaps because we'll have a
- * number of trajectories at once, and along with them summary
- * statistics such as the mean or median.
- *
- * Using some key-value mapping will likely end up being a bit
- * limiting eventually, because we have no easy place to store the
- * metadata that we'll want (these 5 traces all correspond to variable
- * 'x' with some parameter for example). So here, we'll use something
- * deliberately simple but easy to extend. It does not try to closely
- * match the plotly interface (wodin will take care of that instead).
- *
- * Later, we might want to swap the modelling of `y` for something
- * slightly more flexible (either using a multidimensional array or
- * allowing `y` to contain something more exotic per series).
- */
-export interface SeriesSet {
-    /** Names of elements in the series */
-    names: string[];
-    /** The domain that the series is available at, typically time  */
-    x: number[];
-    /**
-     * The values of traces; will have length `names.length` and each
-     * element will have length `x.length`, so that `y[i][j]` is the
-     * `j`th time point of the `i`th series
-     */
-    y: number[][];
-}
-
-/**
- * An interpolated solution to a system of differential equations,
- * typically created via {@link wodinRun}
- *
- * @param t0 Start time to return the solution (cannot be less than
- * the originally used `tStart` - we will increase it to `tStart` in
- * that case)
- *
- * @param t1 End time to return the solution (cannot be more than the
- * originally used `tEnd` - we will reduce it to `tEnd` in that case)
- *
- * @param nPoints Number of points to return - must be at least
- * one, and points will be evenly spaced between `t0` and `t1`
- */
-export type InterpolatedSolution =
-    (t0: number, t1: number, nPoints: number) => SeriesSet;
 
 /**
  * Constructor for an {@link OdinModel}
@@ -266,31 +212,4 @@ function runModelDDE(model: OdinModelDDE, y0: number[] | null,
     solver.initialise(tStart, y0);
     return {solution: solver.run(tEnd),
             statistics: solver.statistics()};
-}
-
-/**
- * Conversion function for Dopri output into plotly input, allowing
- * efficient re-interpolation of subsets of the graph.
- *
- * @param solution The solution as returned from the solver
- *
- * @param names Vector of names for the traces
- *
- * @param tStart Starting time for the integration
- *
- * @param tEnd End time for the integration
- */
-export function interpolatedSolution(solution: FullSolution,
-                                     names: string[],
-                                     tStart: number,
-                                     tEnd: number): InterpolatedSolution {
-    return (t0: number, t1: number, nPoints: number): SeriesSet => {
-        const t = grid(Math.max(tStart, t0), Math.min(tEnd, t1), nPoints);
-        const values = solution(t);
-        // this is basically a transpose, pulling out every series in
-        // turn
-        const y = values[0].map(
-            (_: any, i: number) => values.map((row: number[]) => row[i]));
-        return { names, x: t, y };
-    };
 }

--- a/src/solution.ts
+++ b/src/solution.ts
@@ -1,0 +1,82 @@
+import { FullSolution } from "./model";
+import { grid } from "./util";
+
+/**
+ * We return a set of series from a few different places:
+ *
+ * * {@link wodinRun} returns the full set of series
+ * * {@link wodinFit} returns a single series with just the fit data
+ * * {@link batchRun} returns a number of full sets of series
+ *
+ * Later, when we get going with the stochastic interface, we'll need
+ * a slightly more flexible interface perhaps because we'll have a
+ * number of trajectories at once, and along with them summary
+ * statistics such as the mean or median.
+ *
+ * Using some key-value mapping will likely end up being a bit
+ * limiting eventually, because we have no easy place to store the
+ * metadata that we'll want (these 5 traces all correspond to variable
+ * 'x' with some parameter for example). So here, we'll use something
+ * deliberately simple but easy to extend. It does not try to closely
+ * match the plotly interface (wodin will take care of that instead).
+ *
+ * Later, we might want to swap the modelling of `y` for something
+ * slightly more flexible (either using a multidimensional array or
+ * allowing `y` to contain something more exotic per series).
+ */
+export interface SeriesSet {
+    /** Names of elements in the series */
+    names: string[];
+    /** The domain that the series is available at, typically time  */
+    x: number[];
+    /**
+     * The values of traces; will have length `names.length` and each
+     * element will have length `x.length`, so that `y[i][j]` is the
+     * `j`th time point of the `i`th series
+     */
+    y: number[][];
+}
+
+/**
+ * An interpolated solution to a system of differential equations,
+ * typically created via {@link wodinRun}
+ *
+ * @param t0 Start time to return the solution (cannot be less than
+ * the originally used `tStart` - we will increase it to `tStart` in
+ * that case)
+ *
+ * @param t1 End time to return the solution (cannot be more than the
+ * originally used `tEnd` - we will reduce it to `tEnd` in that case)
+ *
+ * @param nPoints Number of points to return - must be at least
+ * one, and points will be evenly spaced between `t0` and `t1`
+ */
+export type InterpolatedSolution =
+    (t0: number, t1: number, nPoints: number) => SeriesSet;
+
+/**
+ * Conversion function for Dopri output into plotly input, allowing
+ * efficient re-interpolation of subsets of the graph.
+ *
+ * @param solution The solution as returned from the solver
+ *
+ * @param names Vector of names for the traces
+ *
+ * @param tStart Starting time for the integration
+ *
+ * @param tEnd End time for the integration
+ */
+export function interpolatedSolution(solution: FullSolution,
+                                     names: string[],
+                                     tStart: number,
+                                     tEnd: number): InterpolatedSolution {
+    return (t0: number, t1: number, nPoints: number): SeriesSet => {
+        const t = grid(Math.max(tStart, t0), Math.min(tEnd, t1), nPoints);
+        const values = solution(t);
+        // this is basically a transpose, pulling out every series in
+        // turn
+        const y = values[0].map(
+            (_: any, i: number) => values.map((row: number[]) => row[i]));
+        return { names, x: t, y };
+    };
+}

--- a/src/solution.ts
+++ b/src/solution.ts
@@ -37,12 +37,17 @@ export interface SeriesSet {
     y: number[][];
 }
 
+export enum TimeMode {
+    Grid = "grid",
+    Given = "given",
+}
+
 /**
  * Evenly spaced time between `tStart` and `tEnd`
  */
 export interface TimeGrid {
     /** Literal field, indicates this represents a grid of times */
-    mode: "grid";
+    mode: TimeMode.Grid;
     /** Start time to return the solution (cannot be less than the
      *  originally used `tStart` - we will increase it to the original
      *  `tStart` in that case)
@@ -65,7 +70,7 @@ export interface TimeGrid {
  */
 export interface TimeGiven {
     /** Literal field, indicates this represents a given array of times */
-    mode: "given";
+    mode: TimeMode.Given;
     /** A vector of times to return the solution at */
     times: number[];
 }
@@ -79,11 +84,11 @@ export type Times = TimeGrid | TimeGiven;
 function interpolationTimes(times: Times, tStart: number,
                             tEnd: number): number[] {
     switch (times.mode) {
-        case "grid":
+        case TimeMode.Grid:
             return grid(Math.max(tStart, times.tStart),
                         Math.min(tEnd, times.tEnd),
                         times.nPoints);
-        case "given":
+        case TimeMode.Given:
             // We could check here that the solution spans the
             // requested times but that probably causes more issues
             // than it's worth?

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -3,6 +3,6 @@ export function versions() {
     return {
         dfoptim: "0.0.5",
         dopri: "0.0.12",
-        odinjs: "0.0.10",
+        odinjs: "0.0.14",
     };
 }

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -5,7 +5,7 @@ import { base } from "./base";
 import { FitData, FitPars, fitTarget, sumOfSquares } from "./fit";
 import type { OdinModelConstructable, Solution } from "./model";
 import { runModel } from "./model";
-import { interpolatedSolution, InterpolatedSolution } from "./solution";
+import { interpolatedSolution, InterpolatedSolution, TimeMode } from "./solution";
 import type { UserType } from "./user";
 
 /** The "run" method for wodin; this runs the model and returns a
@@ -94,7 +94,7 @@ export function wodinFit(Model: OdinModelConstructable, data: FitData,
  */
 export function wodinFitValue(solution: InterpolatedSolution, data: FitData,
                               modelledSeries: string): number {
-    const { names, y } = solution({ mode: "given", times: data.time });
+    const { names, y } = solution({ mode: TimeMode.Given, times: data.time });
     const idxModel = names.indexOf(modelledSeries);
     return sumOfSquares(data.value, y[idxModel]);
 }

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -2,10 +2,10 @@ import { Simplex, SimplexControlParam } from "dfoptim";
 import type { DopriControlParam } from "dopri";
 
 import { base } from "./base";
-import { FitData, FitPars, fitTarget } from "./fit";
+import { FitData, FitPars, fitTarget, sumOfSquares } from "./fit";
 import type { OdinModelConstructable, Solution } from "./model";
 import { runModel } from "./model";
-import { interpolatedSolution } from "./solution";
+import { interpolatedSolution, InterpolatedSolution } from "./solution";
 import type { UserType } from "./user";
 
 /** The "run" method for wodin; this runs the model and returns a
@@ -82,14 +82,19 @@ export function wodinFit(Model: OdinModelConstructable, data: FitData,
 }
 
 /**
- * Create a baseline for a fit, before the parameters to be varied in
- * the fit are known. This runs an integration with the base
- * parameters and returns everything that {@link wodinFit} would.
+ * Compute the goodness of fit (currently always sum of squares) for a
+ * solution. This can be used to quickly get the same goodness of fit
+ * measure as `wodinFit` but before the parameters to vary are known
+ *
+ * @param solution Solution, created by running {@link wodinRun}
+ *
+ * @param data Data being fit to
+ *
+ * @param modelledSeries Name of the modelled series being fit to
  */
-export function wodinFitBaseline(Model: OdinModelConstructable, data: FitData,
-                                 pars: UserType, modelledSeries: string,
-                                 controlODE: Partial<DopriControlParam>) {
-    const parsFit = { base: pars, vary: [] };
-    const target = fitTarget(Model, data, parsFit, modelledSeries, controlODE);
-    return target([]);
+export function wodinFitValue(solution: InterpolatedSolution, data: FitData,
+                              modelledSeries: string): number {
+    const { names, y } = solution({ mode: "given", times: data.time });
+    const idxModel = names.indexOf(modelledSeries);
+    return sumOfSquares(data.value, y[idxModel]);
 }

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -4,7 +4,8 @@ import type { DopriControlParam } from "dopri";
 import { base } from "./base";
 import { FitData, FitPars, fitTarget } from "./fit";
 import type { OdinModelConstructable, Solution } from "./model";
-import { interpolatedSolution, runModel } from "./model";
+import { runModel } from "./model";
+import { interpolatedSolution } from "./solution";
 import type { UserType } from "./user";
 
 /** The "run" method for wodin; this runs the model and returns a

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -84,13 +84,14 @@ describe("run sensitivity", () => {
         const central = wodinRun(User, user, tStart, tEnd, control);
         const lower = wodinRun(User, { a: 0 }, tStart, tEnd, control);
         const upper = wodinRun(User, { a: 4 }, tStart, tEnd, control);
-        const n = 11;
-        expect(res.solutions[2](tStart, tEnd, n))
-            .toEqual(central(tStart, tEnd, n));
-        expect(res.solutions[0](tStart, tEnd, n))
-            .toEqual(lower(tStart, tEnd, n));
-        expect(res.solutions[4](tStart, tEnd, n))
-            .toEqual(upper(tStart, tEnd, n));
+        const nPoints = 11;
+        const times = { mode: "grid", tStart, tEnd, nPoints } as const;
+        expect(res.solutions[2](times))
+            .toEqual(central(times));
+        expect(res.solutions[0](times))
+            .toEqual(lower(times));
+        expect(res.solutions[4](times))
+            .toEqual(upper(times));
     });
 });
 

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -1,4 +1,5 @@
 import { batchParsDisplace, batchParsRange, batchRun, updatePars } from "../src/batch";
+import { TimeMode } from "../src/solution";
 import { grid, gridLog } from "../src/util";
 import { wodinRun } from "../src/wodin";
 
@@ -85,7 +86,7 @@ describe("run sensitivity", () => {
         const lower = wodinRun(User, { a: 0 }, tStart, tEnd, control);
         const upper = wodinRun(User, { a: 4 }, tStart, tEnd, control);
         const nPoints = 11;
-        const times = { mode: "grid", tStart, tEnd, nPoints } as const;
+        const times = { mode: TimeMode.Grid, tStart, tEnd, nPoints } as const;
         expect(res.solutions[2](times))
             .toEqual(central(times));
         expect(res.solutions[0](times))

--- a/test/fit.test.ts
+++ b/test/fit.test.ts
@@ -1,5 +1,6 @@
 import * as models from "./models";
 import {fitTarget, sumOfSquares} from "../src/fit";
+import { TimeMode } from "../src/solution";
 import {grid} from "../src/util";
 import {UserValue} from "../src/user";
 
@@ -41,7 +42,7 @@ describe("fitTarget", () => {
         const control = {};
         const target = fitTarget(models.User, data, pars, modelledSeries, control);
         const res = target([0.5]);
-        const sol = res.data.solution({ mode: "grid", tStart: 0, tEnd: 5, nPoints: 6 });
+        const sol = res.data.solution({ mode: TimeMode.Grid, tStart: 0, tEnd: 5, nPoints: 6 });
         const expectedX = grid(0, 5, 6);
         const expectedY = expectedX.map((el) => 1 + el * 0.5);
         expect(sol.x).toStrictEqual(expectedX);

--- a/test/fit.test.ts
+++ b/test/fit.test.ts
@@ -41,7 +41,7 @@ describe("fitTarget", () => {
         const control = {};
         const target = fitTarget(models.User, data, pars, modelledSeries, control);
         const res = target([0.5]);
-        const sol = res.data.solution(0, 5, 6);
+        const sol = res.data.solution({ mode: "grid", tStart: 0, tEnd: 5, nPoints: 6 });
         const expectedX = grid(0, 5, 6);
         const expectedY = expectedX.map((el) => 1 + el * 0.5);
         expect(sol.x).toStrictEqual(expectedX);

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -18,7 +18,7 @@ describe("can run basic models", () => {
         const control : any = {};
         const solution = wodinRun(models.Minimal, user, 0, 10, control);
 
-        const y = solution(0, 10, 11);
+        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
         expect(y.names).toEqual(["x"]);
@@ -32,7 +32,7 @@ describe("can run basic models", () => {
         const control : any = {};
         const solution = wodinRun(models.Output, user, 0, 10, control);
 
-        const y = solution(0, 10, 11);
+        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
         const expectedY = expectedX.map((x: number) => x * 2);
@@ -47,7 +47,7 @@ describe("can run basic models", () => {
         const user = {};
         const control : any = {};
         const solution = wodinRun(models.Delay, user, 0, 10, control);
-        const y = solution(0, 10, 11);
+        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
 
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
@@ -63,7 +63,7 @@ describe("can run basic models", () => {
         const user = {};
         const control : any = {};
         const solution = wodinRun(models.DelayNoOutput, user, 0, 10, control);
-        const y = solution(0, 10, 11);
+        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
 
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
@@ -85,7 +85,7 @@ describe("can run basic models", () => {
 
         const expectedT = grid(0, pi, 11);
         const expectedY = expectedT.map((t: number) => 1 - Math.cos(t));
-        const y = solution(0, pi, 11);
+        const y = solution({ mode: "grid", tStart: 0, tEnd: pi, nPoints: 11 });
         expect(approxEqualArray(y.y[0], expectedY, 1e-4)).toBe(true);
     });
 
@@ -95,7 +95,7 @@ describe("can run basic models", () => {
         const user = { tp, zp };
         const control: any = {};
         const solution = wodinRun(models.InterpolateArray, user, 0, 3, control);
-        const y = solution(0, 3, 51);
+        const y = solution({ mode: "grid", tStart: 0, tEnd: 3, nPoints: 51 });
         const t = y.x;
         const z1 = t.map((t: number) => t < 1 ? 0 : (t > 2 ? 1 : t - 1));
         const z2 = t.map((t: number) => t < 1 ? 0 : (t > 2 ? 2 : 2 * (t - 1)));
@@ -111,8 +111,8 @@ describe("can set user", () => {
         const control : any = {};
         const solution1 = wodinRun(models.Minimal, pars1, 0, 10, control);
         const solution2 = wodinRun(models.User, pars2, 0, 10, control);
-        const y1 = solution1(0, 10, 11);
-        const y2 = solution2(0, 10, 11);
+        const y1 = solution1({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
+        const y2 = solution2({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
         expect(y1).toEqual(y2);
     });
 
@@ -122,8 +122,8 @@ describe("can set user", () => {
         const control : any = {};
         const solution1 = wodinRun(models.User, pars1, 0, 10, control);
         const solution2 = wodinRun(models.User, pars2, 0, 10, control);
-        const y1 = solution1(0, 10, 11);
-        const y2 = solution2(0, 10, 11);
+        const y1 = solution1({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
+        const y2 = solution2({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
         expect(y1).toEqual(y2);
     });
 
@@ -131,7 +131,7 @@ describe("can set user", () => {
         const pars = { "a": 2 };
         const control : any = {};
         const solution = wodinRun(models.User, pars, 0, 10, control);
-        const y = solution(0, 10, 11);
+        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
         const expectedX = grid(0, 10, 11);
         const expectedY = expectedX.map((t: number) => t * 2 + 1);
         expect(y.names).toEqual(["x"]);
@@ -159,7 +159,7 @@ describe("can fit a simple line", () => {
         expect(res.data.pars["a"]).toEqual(res.location[0]);
         expect(res.data.endTime).toEqual(6);
 
-        const yFit = res.data.solution(0, 6, 7);
+        const yFit = res.data.solution({ mode: "grid", tStart: 0, tEnd: 6, nPoints: 7 });
         expect(yFit.names).toEqual(["x"]);
         expect(yFit.x).toEqual(time);
         expect(approxEqualArray(yFit.y[0], data.value)).toBe(true);
@@ -193,7 +193,7 @@ describe("can run a baseline", () => {
         expect(res.data.pars).toEqual(pars);
         expect(res.data.endTime).toEqual(6);
 
-        const yFit = res.data.solution(0, 6, 7);
+        const yFit = res.data.solution({ mode: "grid", tStart: 0, tEnd: 6, nPoints: 7 });
         expect(yFit.names).toEqual(["x"]);
         expect(yFit.x).toEqual(time);
         expect(yFit.y[0]).toEqual([1, 1.5, 2, 2.5, 3, 3.5, 4]);

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,3 +1,4 @@
+import { TimeMode } from "../src/solution";
 import { wodinFit, wodinFitValue, wodinRun } from "../src/wodin";
 import {UserTensor, UserValue} from "../src/user";
 import {grid} from "../src/util";
@@ -18,7 +19,7 @@ describe("can run basic models", () => {
         const control : any = {};
         const solution = wodinRun(models.Minimal, user, 0, 10, control);
 
-        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
+        const y = solution({ mode: TimeMode.Grid, tStart: 0, tEnd: 10, nPoints: 11 });
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
         expect(y.names).toEqual(["x"]);
@@ -32,7 +33,7 @@ describe("can run basic models", () => {
         const control : any = {};
         const solution = wodinRun(models.Output, user, 0, 10, control);
 
-        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
+        const y = solution({ mode: TimeMode.Grid, tStart: 0, tEnd: 10, nPoints: 11 });
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
         const expectedY = expectedX.map((x: number) => x * 2);
@@ -47,7 +48,7 @@ describe("can run basic models", () => {
         const user = {};
         const control : any = {};
         const solution = wodinRun(models.Delay, user, 0, 10, control);
-        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
+        const y = solution({ mode: TimeMode.Grid, tStart: 0, tEnd: 10, nPoints: 11 });
 
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
@@ -63,7 +64,7 @@ describe("can run basic models", () => {
         const user = {};
         const control : any = {};
         const solution = wodinRun(models.DelayNoOutput, user, 0, 10, control);
-        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
+        const y = solution({ mode: TimeMode.Grid, tStart: 0, tEnd: 10, nPoints: 11 });
 
         const expectedT = grid(0, 10, 11);
         const expectedX = expectedT.map((t: number) => t + 1);
@@ -85,7 +86,7 @@ describe("can run basic models", () => {
 
         const expectedT = grid(0, pi, 11);
         const expectedY = expectedT.map((t: number) => 1 - Math.cos(t));
-        const y = solution({ mode: "grid", tStart: 0, tEnd: pi, nPoints: 11 });
+        const y = solution({ mode: TimeMode.Grid, tStart: 0, tEnd: pi, nPoints: 11 });
         expect(approxEqualArray(y.y[0], expectedY, 1e-4)).toBe(true);
     });
 
@@ -95,7 +96,7 @@ describe("can run basic models", () => {
         const user = { tp, zp };
         const control: any = {};
         const solution = wodinRun(models.InterpolateArray, user, 0, 3, control);
-        const y = solution({ mode: "grid", tStart: 0, tEnd: 3, nPoints: 51 });
+        const y = solution({ mode: TimeMode.Grid, tStart: 0, tEnd: 3, nPoints: 51 });
         const t = y.x;
         const z1 = t.map((t: number) => t < 1 ? 0 : (t > 2 ? 1 : t - 1));
         const z2 = t.map((t: number) => t < 1 ? 0 : (t > 2 ? 2 : 2 * (t - 1)));
@@ -111,8 +112,8 @@ describe("can set user", () => {
         const control : any = {};
         const solution1 = wodinRun(models.Minimal, pars1, 0, 10, control);
         const solution2 = wodinRun(models.User, pars2, 0, 10, control);
-        const y1 = solution1({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
-        const y2 = solution2({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
+        const y1 = solution1({ mode: TimeMode.Grid, tStart: 0, tEnd: 10, nPoints: 11 });
+        const y2 = solution2({ mode: TimeMode.Grid, tStart: 0, tEnd: 10, nPoints: 11 });
         expect(y1).toEqual(y2);
     });
 
@@ -122,8 +123,8 @@ describe("can set user", () => {
         const control : any = {};
         const solution1 = wodinRun(models.User, pars1, 0, 10, control);
         const solution2 = wodinRun(models.User, pars2, 0, 10, control);
-        const y1 = solution1({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
-        const y2 = solution2({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
+        const y1 = solution1({ mode: TimeMode.Grid, tStart: 0, tEnd: 10, nPoints: 11 });
+        const y2 = solution2({ mode: TimeMode.Grid, tStart: 0, tEnd: 10, nPoints: 11 });
         expect(y1).toEqual(y2);
     });
 
@@ -131,7 +132,7 @@ describe("can set user", () => {
         const pars = { "a": 2 };
         const control : any = {};
         const solution = wodinRun(models.User, pars, 0, 10, control);
-        const y = solution({ mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 });
+        const y = solution({ mode: TimeMode.Grid, tStart: 0, tEnd: 10, nPoints: 11 });
         const expectedX = grid(0, 10, 11);
         const expectedY = expectedX.map((t: number) => t * 2 + 1);
         expect(y.names).toEqual(["x"]);
@@ -159,7 +160,7 @@ describe("can fit a simple line", () => {
         expect(res.data.pars["a"]).toEqual(res.location[0]);
         expect(res.data.endTime).toEqual(6);
 
-        const yFit = res.data.solution({ mode: "grid", tStart: 0, tEnd: 6, nPoints: 7 });
+        const yFit = res.data.solution({ mode: TimeMode.Grid, tStart: 0, tEnd: 6, nPoints: 7 });
         expect(yFit.names).toEqual(["x"]);
         expect(yFit.x).toEqual(time);
         expect(approxEqualArray(yFit.y[0], data.value)).toBe(true);

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,4 +1,4 @@
-import { wodinFit, wodinFitBaseline, wodinRun } from "../src/wodin";
+import { wodinFit, wodinFitValue, wodinRun } from "../src/wodin";
 import {UserTensor, UserValue} from "../src/user";
 import {grid} from "../src/util";
 
@@ -178,24 +178,17 @@ describe("can fit a simple line", () => {
     });
 });
 
-describe("can run a baseline", () => {
-    it("Can fit a simple model", () => {
+describe("can get sum of squares from model solution", () => {
+    it("returns correct number", () => {
         const time = [0, 1, 2, 3, 4, 5, 6];
         const data = {time, value: time.map((t: number) => 1 + t * 4)}
         const pars = { "a": 0.5 };
         const modelledSeries = "x";
         const controlODE = {};
-        const res = wodinFitBaseline(models.User, data, pars, modelledSeries,
-                                     controlODE);
-        // sum((1 + (1:6) * 0.5 - (1 + (1:6) * 4))^2)
-        expect(res.value).toBeCloseTo(1114.75);
-        expect(res.data.names).toEqual(["x"]);
-        expect(res.data.pars).toEqual(pars);
-        expect(res.data.endTime).toEqual(6);
 
-        const yFit = res.data.solution({ mode: "grid", tStart: 0, tEnd: 6, nPoints: 7 });
-        expect(yFit.names).toEqual(["x"]);
-        expect(yFit.x).toEqual(time);
-        expect(yFit.y[0]).toEqual([1, 1.5, 2, 2.5, 3, 3.5, 4]);
+        const solution = wodinRun(models.User, pars, 0, 10, controlODE);
+        const res = wodinFitValue(solution, data, modelledSeries);
+        // sum((1 + (1:6) * 0.5 - (1 + (1:6) * 4))^2)
+        expect(res).toBeCloseTo(1114.75);
     });
 });


### PR DESCRIPTION
Walking back the baseline idea (#13) as that requires rerunning the model automatically which we said we'd not do.

This idea takes the existing central solution along with the data and computes sum-of-squares with it. There's no need to know which parameters will vary, just the data and the modelled trace in question. We should be able to use this to be able to quickly change the statistics in the fit plot

Eventually appears in wodin as https://github.com/mrc-ide/wodin/pull/86