### PR TITLE
Enforce that fit time starts at zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -68,7 +68,10 @@ export function fitTarget(Model: OdinModelConstructable,
                           data: FitData, pars: FitPars,
                           modelledSeries: string,
                           control: any) {
-    const tStart = data.time[0];
+    const tStart = 0;
+    if (data.time[0] < tStart) {
+        throw Error(`Expected the first time to be at least ${tStart}`);
+    }
     const tEnd = data.time[data.time.length - 1];
     return (theta: number[]): FitResult => {
         const p = updatePars(pars, theta);

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -87,12 +87,12 @@ export function fitTarget(Model: OdinModelConstructable,
         return {
             /** Additional data alongside the goodness of fit, see above */
             data: {
-                startTime: tStart,
                 endTime: tEnd,
                 names,
                 pars: p,
                 solution: interpolatedSolution(
                     solution, names, tStart, tEnd),
+                startTime: tStart,
             },
             /** Goodness of fit, the sum-of-squared differences
              * between the observed data and the modelled series

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -59,6 +59,8 @@ export interface FitResult extends Result {
          *   function as as would be returned by {@link wodinRun}
          */
         solution: InterpolatedSolution;
+        /** The start time of the integration */
+        startTime: number;
     };
     /** The sum of squares for this set of parameters */
     value: number;
@@ -85,6 +87,7 @@ export function fitTarget(Model: OdinModelConstructable,
         return {
             /** Additional data alongside the goodness of fit, see above */
             data: {
+                startTime: tStart,
                 endTime: tEnd,
                 names,
                 pars: p,

--- a/test/fit.test.ts
+++ b/test/fit.test.ts
@@ -1,5 +1,6 @@
 import * as models from "./models";
 import {fitTarget, sumOfSquares} from "../src/fit";
+import {grid} from "../src/util";
 import {UserValue} from "../src/user";
 
 import {approxEqualArray} from "./helpers";
@@ -20,3 +21,30 @@ describe("sumOfSquares", () => {
         expect(sumOfSquares(Array(6).fill(NaN), x)).toEqual(0);
     });
 })
+
+describe("fitTarget", () => {
+    it("requires that the first time is at least zero", () => {
+        const time = [-1, 0, 1, 2, 3, 4, 5];
+        const data = {time, value: time.map((t: number) => 1 + t * 4)}
+        const pars = { base: { "a": 0.5 }, vary: ["a"] };
+        const modelledSeries = "x";
+        const control = {};
+        expect(() => fitTarget(models.User, data, pars, modelledSeries, control))
+            .toThrow("Expected the first time to be at least 0");
+    });
+
+    it("if time is nonzero, model run includes zero", () => {
+        const time = [1, 2, 3, 4, 5];
+        const data = {time, value: time.map((t: number) => 1 + t * 4)}
+        const pars = { base: { "a": 0.5 }, vary: ["a"] };
+        const modelledSeries = "x";
+        const control = {};
+        const target = fitTarget(models.User, data, pars, modelledSeries, control);
+        const res = target([0.5]);
+        const sol = res.data.solution(0, 5, 6);
+        const expectedX = grid(0, 5, 6);
+        const expectedY = expectedX.map((el) => 1 + el * 0.5);
+        expect(sol.x).toStrictEqual(expectedX);
+        expect(approxEqualArray(sol.y[0], expectedY)).toBe(true);
+    });
+});


### PR DESCRIPTION
This fixes the difference between run and fit so that both always start at zero. 

There's still a slight difference in that wodinRun can take tStart and tEnd (indeed it has to) but wodinFit runs from 0 to the end of the data. However, that's exactly what the app wants right now so that's ok I think. A better solution would be to allow control over these but we're going to end up with a ton of parameters to the function if we're not careful