### PR TITLE
Allow a fraction of batch runs to fail, but still return

### DIFF
--- a/src/batch.ts
+++ b/src/batch.ts
@@ -62,7 +62,7 @@ export class Batch {
         // We need to think about this error, though it should not
         // come out that often...
         if (solutions.length === 0) {
-            throw Error("All solutions failed");
+            throw Error(`All solutions failed; first error: ${errors[0].error}`);
         }
 
         // We actually only use the value here, so could just save

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -4,7 +4,7 @@ import { grid, gridLog } from "../src/util";
 import { wodinRun } from "../src/wodin";
 
 import { approxEqualArray } from "./helpers";
-import { Output, User } from "./models";
+import { Oscillate, Output, User } from "./models";
 
 describe("Can generate sensible sets of parameters", () => {
     it("Generates a simple sequence", () => {
@@ -93,6 +93,27 @@ describe("run sensitivity", () => {
             .toEqual(lower(times));
         expect(res.solutions[4](times))
             .toEqual(upper(times));
+    });
+
+    it("catches errors in fraction of runs", () => {
+        const pars = {
+            base: { scale: 1 },
+            name: "scale",
+            values: [0.01, 0.1, 1, 10, 100],
+        };
+        const control = {maxSteps: 100};
+        const res = batchRun(Oscillate, pars, 0, 10, control);
+        // This will be 2 unless we change the behaviour of dopri
+        expect(res.errors.length).toEqual(2);
+        expect(res.errors[0].value).toEqual(10);
+        expect(res.errors[1].value).toEqual(100);
+        expect(res.errors[0].error).toMatch("too many steps");
+
+        expect(res.solutions.length).toBe(3);
+        expect(res.pars.values).toEqual([0.01, 0.1, 1]);
+
+        // Summaries also work over the reduced set of solutions
+        expect(res.valueAtTime(10).x.length).toEqual(3);
     });
 });
 

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -115,6 +115,22 @@ describe("run sensitivity", () => {
         // Summaries also work over the reduced set of solutions
         expect(res.valueAtTime(10).x.length).toEqual(3);
     });
+
+    // This is very unlikely to happen in practice because we require
+    // that the central solution is within the range. It might happen
+    // around a point where we're on the edge of failing though and it
+    // depends critically on the tolerances and number of steps.
+    it("throws if all runs fail", () => {
+        const pars = {
+            base: { scale: 1 },
+            name: "scale",
+            values: [0.01, 0.1, 1, 10, 100],
+        };
+        const control = {maxSteps: 1};
+        // Not the world's most lovely error, but hopefully rare in practice.
+        expect(() => batchRun(Oscillate, pars, 0, 10, control))
+            .toThrow("All solutions failed; first error: Integration failure: too many steps");
+    });
 });
 
 describe("can extract from a batch result", () => {

--- a/test/models.ts
+++ b/test/models.ts
@@ -395,3 +395,42 @@ export class InterpolateArray {
         return this.metadata;
     }
 }
+
+// @ts-nocheck
+export class Oscillate {
+    // A simple example with a system we can control the amount of
+    // work it does
+    constructor(base, user, unusedUserAction) {
+        this.base = base;
+        this.internal = {};
+        this.setUser(user, unusedUserAction);
+    }
+
+    rhs(t, state, dstatedt) {
+        var internal = this.internal;
+        dstatedt[0] = Math.sin(t * internal.scale);
+    }
+
+    initial(t) {
+        return [1];
+    }
+
+    names() {
+        return ["y"];
+    }
+
+    setUser(user, unusedUserAction) {
+        const internal = this.internal;
+        this.base.user.checkUser(user, ["scale"], unusedUserAction);
+        this.base.user.setUserScalar(user, "scale", internal, 1,
+                                     -Infinity, Infinity, false);
+    }
+
+    getInternal() {
+        return this.internal;
+    }
+
+    getMetadata() {
+        return {};
+    }
+}


### PR DESCRIPTION
This PR allows batch runs to return fewer than the full complement of runs, fixing an issue seen in real-world use of the models.

The interface is unchanged for wodin, because it just uses the solutions array - this might now be shorter than expected, but I think that it should just work.

We can then check for a nonzero length to the errors property, and report nicely on this