### PR TITLE
Iteratable batch runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.19",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/odinjs",
-            "version": "0.0.19",
+            "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
                 "@reside-ic/interpolate": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.0.19",
+    "version": "0.1.0",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -48,7 +48,7 @@ export class Batch {
         this.tEnd = tEnd;
         this.solutions = [];
         this.errors = [];
-        this._pending = pars.values;;
+        this._pending = pars.values;
         this._run = run;
     }
 
@@ -68,7 +68,7 @@ export class Batch {
                 this.solutions.push(this._run(p, this.tStart, this.tEnd));
                 this.pars.values.push(value);
             } catch (e: any) {
-                this.errors.push({value: value, error: (e as Error).message});
+                this.errors.push({ value, error: (e as Error).message });
             }
         }
         const isComplete = this._pending.length === 0;
@@ -84,6 +84,7 @@ export class Batch {
      */
     public run(): void {
         while (!this.compute()) {
+            // tslint:disable-next-line:no-empty
         }
     }
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -43,6 +43,8 @@ export class Batch {
      * @param control Optional control parameters to tune the integration
      */
     constructor(run: singleBatchRun, pars: BatchPars, tStart: number, tEnd: number) {
+        // Start with an empty BatchPars object, we'll re-add values
+        // as they are successfully computed later.
         this.pars = { ...pars, values: [] as number[]};
         this.tStart = tStart;
         this.tEnd = tEnd;

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -25,6 +25,8 @@ export class Batch {
     public readonly errors: BatchError[];
 
     private _extremes?: Extremes<SeriesSet>;
+    private _pending: number[];
+    private readonly _run: singleBatchRun;
 
     /** Construct a batch run, which will run the model many times
      *
@@ -41,35 +43,48 @@ export class Batch {
      * @param control Optional control parameters to tune the integration
      */
     constructor(run: singleBatchRun, pars: BatchPars, tStart: number, tEnd: number) {
-        this.pars = pars;
+        this.pars = { ...pars, values: [] as number[]};
         this.tStart = tStart;
         this.tEnd = tEnd;
+        this.solutions = [];
+        this.errors = [];
+        this._pending = pars.values;;
+        this._run = run;
+    }
 
-        const solutions = [] as InterpolatedSolution[];
-        const errors = [] as BatchError[];
-        const values = [] as number[];
-
-        pars.values.forEach((v: number) => {
-            const p = updatePars(pars.base, pars.name, v);
+    /**
+     * Compute the next parameter set in the batch. If all have been
+     * computed, the method will return very quickly but not error.
+     *
+     * @return `true` if all parameter sets have been computed,
+     * `false` otherwise.
+     */
+    public compute(): boolean {
+        if (this._pending.length > 0) {
+            const value = this._pending[0];
+            this._pending = this._pending.slice(1);
+            const p = updatePars(this.pars.base, this.pars.name, value);
             try {
-                solutions.push(run(p, tStart, tEnd));
-                values.push(v);
+                this.solutions.push(this._run(p, this.tStart, this.tEnd));
+                this.pars.values.push(value);
             } catch (e: any) {
-                errors.push({value: v, error: (e as Error).message});
+                this.errors.push({value: value, error: (e as Error).message});
             }
-        });
-
-        // We need to think about this error, though it should not
-        // come out that often...
-        if (solutions.length === 0) {
-            throw Error(`All solutions failed; first error: ${errors[0].error}`);
         }
+        const isComplete = this._pending.length === 0;
+        if (isComplete && this.solutions.length === 0) {
+            throw Error(`All solutions failed; first error: ${this.errors[0].error}`);
+        }
+        return isComplete;
+    }
 
-        // We actually only use the value here, so could just save
-        // that, and not the rest, really.
-        this.pars = {...pars, values};
-        this.solutions = solutions;
-        this.errors = errors;
+    /**
+     * Convenience function for computing all parameter sets in one
+     * blocking loop.
+     */
+    public run(): void {
+        while (!this.compute()) {
+        }
     }
 
     /**
@@ -170,13 +185,21 @@ export interface BatchError {
  * @param tEnd End of the integration (must be greater than `tStart`)
  *
  * @param control Optional control parameters to tune the integration
+ *
+ * @param immediate Indicates if we should immediately compute all
+ * solutions in the batch (may take a while).
  */
 export function batchRun(Model: OdinModelConstructable, pars: BatchPars,
                          tStart: number, tEnd: number,
-                         control: Partial<DopriControlParam>): Batch {
+                         control: Partial<DopriControlParam>,
+                         immediate: boolean = true): Batch {
     const run = (p: UserType, t0: number, t1: number) =>
         wodinRun(Model, p, t0, t1, control);
-    return new Batch(run, pars, tStart, tEnd);
+    const ret = new Batch(run, pars, tStart, tEnd);
+    if (immediate) {
+        ret.run();
+    }
+    return ret;
 }
 
 /** Generate a set of parameters suitable to pass through to {@link

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -3,6 +3,6 @@ export function versions() {
     return {
         dfoptim: "0.0.5",
         dopri: "0.0.12",
-        odinjs: "0.0.19",
+        odinjs: "0.1.0",
     };
 }

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -131,6 +131,29 @@ describe("run sensitivity", () => {
         expect(() => batchRun(Oscillate, pars, 0, 10, control))
             .toThrow("All solutions failed; first error: Integration failure: too many steps");
     });
+
+    it("can run in non-blocking mode", () => {
+        const user = { a: 2 };
+        const pars = batchParsRange(user, "a", 3, false, 0, 4);
+        const control = {};
+        const tStart = 0;
+        const tEnd = 10;
+        const obj = batchRun(User, pars, tStart, tEnd, control, false);
+        expect(obj.solutions.length).toBe(0);
+        expect(obj.errors.length).toBe(0);
+
+        expect(obj.compute()).toBe(false);
+        expect(obj.solutions.length).toBe(1);
+        expect(obj.pars.values).toEqual([0]);
+        expect(obj.compute()).toBe(false);
+        expect(obj.solutions.length).toBe(2);
+        expect(obj.pars.values).toEqual([0, 2]);
+        expect(obj.compute()).toBe(true);
+        expect(obj.solutions.length).toBe(3);
+        expect(obj.compute()).toBe(true);
+        expect(obj.solutions.length).toBe(3);
+        expect(obj.pars.values).toEqual([0, 2, 4]);
+    })
 });
 
 describe("can extract from a batch result", () => {


### PR DESCRIPTION
~Includes #23, so review and merge after that.~

Same basic approach as taken in dfoptim with the fits, to provide a non-blocking interface to the sensitivity. You can access solutions (and anything else really) during the fit. We might want to change the order that we iterate through, but it's not immediately obvious what the best order is, so this just goes from small to large!