### PR TITLE
Allow processing multiple summary statistics per series

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/odinjs",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "license": "MIT",
             "dependencies": {
                 "@reside-ic/interpolate": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -3,7 +3,7 @@ import type { DopriControlParam } from "dopri";
 import type { OdinModelConstructable } from "./model";
 import { InterpolatedSolution, SeriesSet, SeriesSetValues, TimeMode, Times } from "./solution";
 import { UserType } from "./user";
-import { grid, gridLog, loop, whichMax, whichMin } from "./util";
+import { grid, gridLog, loop, unique, whichMax, whichMin } from "./util";
 import { wodinRun } from "./wodin";
 
 export type singleBatchRun = (pars: UserType, tStart: number, tEnd: number) => InterpolatedSolution;
@@ -316,7 +316,7 @@ export function computeExtremesResult(x: number[], result: SeriesSet[]): Extreme
         yMin: newSeriesSet(), yMax: newSeriesSet(), tMin: newSeriesSet(), tMax: newSeriesSet()
     };
 
-    const names = result[0].values.map((s) => s.name);
+    const names = unique(result[0].values.map((s) => s.name));
     for (let nm of names) {
         const s = repairDeterministic(nm, result);
         const len = s[0].length;

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -3,7 +3,7 @@ import type { DopriControlParam } from "dopri";
 import type { OdinModelConstructable } from "./model";
 import { InterpolatedSolution, SeriesSet, SeriesSetValues, TimeMode, Times } from "./solution";
 import { UserType } from "./user";
-import { grid, gridLog, loop, sameArrayContents, unique, whichMax, whichMin } from "./util";
+import { grid, gridLog, sameArrayContents, unique, whichMax, whichMin } from "./util";
 import { wodinRun } from "./wodin";
 
 export type singleBatchRun = (pars: UserType, tStart: number, tEnd: number) => InterpolatedSolution;

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -318,7 +318,7 @@ export function computeExtremesResult(x: number[], result: SeriesSet[]): Extreme
 
     const names = unique(result[0].values.map((s) => s.name));
     for (let nm of names) {
-        const s = repairDeterministic(nm, result);
+        const s = repairDeterministic(result.map((r) => r.values.filter((el) => el.name === nm)));
         const len = s[0].length;
         for (let idx = 0; idx < len; ++idx) {
             const extremes = s.map((el) => findExtremes(times, el[idx].y));
@@ -332,8 +332,7 @@ export function computeExtremesResult(x: number[], result: SeriesSet[]): Extreme
     return ret;
 }
 
-function repairDeterministic(name: string, allResults: SeriesSet[]): SeriesSetValues[][] {
-    const result = allResults.map((r) => r.values.filter((el) => el.name === name));
+function repairDeterministic(result: SeriesSetValues[][]): SeriesSetValues[][] {
     const len = result.map((el) => el.length);
     // We should be ok here, but probably worth checking that:
     //

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -294,7 +294,7 @@ function valueAtTime(time: number, x: number[], solutions: InterpolatedSolution[
 // from this.
 //
 // There's a complication where we have deterministic traces mixed in
-// with more than one stochastic summaries; se below for details.
+// with more than one stochastic summaries; see below for details.
 export function valueAtTimeResult(x: number[], result: SeriesSet[]): SeriesSet {
     const ret: SeriesSet = { x, values: [] };
     const names = unique(result[0].values.map((s) => s.name));

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -285,8 +285,8 @@ export function computeExtremes(tStart: number, tEnd: number, x: number[],
     const times = {
         mode: TimeMode.Grid,
         nPoints: n,
-        tEnd: tEnd,
-        tStart: tStart,
+        tEnd,
+        tStart,
     } as const;
     const result = solutions.map((s: InterpolatedSolution) => s(times));
     return computeExtremesResult(x, result);
@@ -307,11 +307,11 @@ export function computeExtremesResult(x: number[], result: SeriesSet[]): Extreme
 
     const newSeriesSet = () => ({ x, values: [] });
     const ret: Extremes<SeriesSet> = {
-        yMin: newSeriesSet(), yMax: newSeriesSet(), tMin: newSeriesSet(), tMax: newSeriesSet()
+        tMax: newSeriesSet(), tMin: newSeriesSet(), yMax: newSeriesSet(), yMin: newSeriesSet(),
     };
 
     const names = unique(result[0].values.map((s) => s.name));
-    for (let nm of names) {
+    for (const nm of names) {
         const s = repairDeterministic(result.map((r) => r.values.filter((el) => el.name === nm)));
         const len = s[0].length;
         for (let idx = 0; idx < len; ++idx) {

--- a/src/solution.ts
+++ b/src/solution.ts
@@ -17,6 +17,12 @@ export interface SeriesSet {
 }
 
 export interface SeriesSetValues {
+    /**
+     * An optional description for this series. This is useful if you
+     * have more than one element with the same `name` within a
+     * particular `SeriesSet`
+     */
+    description?: string;
     /** The name of the series */
     name: string;
     /** The value of the traces, over the time domain */

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,3 +43,7 @@ export function loop<T>(n: number, f: (i: number) => T): T[] {
     }
     return ret;
 }
+
+export function unique<T>(x: T[]): T[] {
+    return [...new Set(x)];
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,3 +47,7 @@ export function loop<T>(n: number, f: (i: number) => T): T[] {
 export function unique<T>(x: T[]): T[] {
     return [...new Set(x)];
 }
+
+export function sameArrayContents<T>(x: T[], y: T[]): boolean {
+    return x.length === y.length && x.every((el: T, idx: number) => y[idx] === el);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,14 +36,6 @@ export function whichMax(x: number[]) {
     return idx;
 }
 
-export function loop<T>(n: number, f: (i: number) => T): T[] {
-    const ret = [];
-    for (let i = 0; i < n; ++i) {
-        ret.push(f(i));
-    }
-    return ret;
-}
-
 export function unique<T>(x: T[]): T[] {
     return [...new Set(x)];
 }

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -3,6 +3,6 @@ export function versions() {
     return {
         dfoptim: "0.0.5",
         dopri: "0.0.12",
-        odinjs: "0.1.0",
+        odinjs: "0.1.1",
     };
 }

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -221,6 +221,7 @@ describe("new", () => {
         // console.log(extremes.tMin.values[0]);
     });
 
+    // This is the trivial dust case; one summary, copy over description
     it("can work with elements that have descriptions", () => {
         const tStart = 0;
         const tEnd = 10;
@@ -232,16 +233,51 @@ describe("new", () => {
             values([1, 2, 3, 4, 5]),
             values([2, 3, 4, 5, 6]),
         ];
-        // console.log(result);
-        // console.log(result[0]);
         const extremes = computeExtremesResult(x, result);
-        // console.log(extremes);
-        // console.log(extremes.tMin);
-        // console.log(extremes.tMin.values[0]);
+        console.log(extremes);
+        console.log(extremes.yMax);
+        console.log(extremes.yMax.values[0]);
+
+        expect(extremes.yMax.x).toStrictEqual(x);
+        expect(extremes.yMax.values.length).toBe(1);
+        expect(extremes.yMax.values[0]).toStrictEqual(
+            { name: "a", y: [4, 5, 6], description: "Mean" });
     });
 
-    // This is the error case that we currently have:
-    it.only("can work with elements that have descriptions", () => {
+    // This is the usual dust case; we have multiple summary
+    // statistics that perfectly align and we want to make sure that
+    // we copy over the descriptions.
+    it.only("can work with multiple summaries", () => {
+        const tStart = 0;
+        const tEnd = 10;
+        const x = [0, 1, 2]; // parameter values
+        const t = [0, 1, 2, 3, 4];
+        const values = (y: number[]) => ({ x: t, values: [
+            { name: "a", y, description: "Mean" },
+            { name: "a", y: y.map((el) => el - 0.5), description: "Min" },
+            { name: "a", y: y.map((el) => el + 0.5), description: "Max" }
+        ]});
+        const result = [
+            values([0, 1, 2, 3, 4]),
+            values([1, 2, 3, 4, 5]),
+            values([2, 3, 4, 5, 6]),
+        ];
+        const extremes = computeExtremesResult(x, result);
+        expect(extremes.yMax.x).toStrictEqual(x);
+        expect(extremes.yMax.values.length).toBe(3);
+        expect(extremes.yMax.values[0]).toStrictEqual(
+            { name: "a", y: [4, 5, 6], description: "Mean" });
+        expect(extremes.yMax.values[1]).toStrictEqual(
+            { name: "a", y: [3.5, 4.5, 5.5], description: "Min" });
+        expect(extremes.yMax.values[2]).toStrictEqual(
+            { name: "a", y: [4.5, 5.5, 6.5], description: "Max" });
+    });
+
+    // This is the motivating case for repairDeterministic; one
+    // parameter set returns a deterministic trace but the other two
+    // have both Mean and Min - we expect that our final set of
+    // extremes will have Mean and Min.
+    it("can work with elements that have descriptions", () => {
         const tStart = 0;
         const tEnd = 10;
         const x = [0, 1, 2]; // parameter values
@@ -261,12 +297,12 @@ describe("new", () => {
             values([1, 2, 3, 4, 5]),
             values([2, 3, 4, 5, 6]),
         ];
-        // console.log(result);
-        // console.log(result[0]);
         const extremes = computeExtremesResult(x, result);
-        console.log(extremes);
-        console.log(extremes.yMax);
-        console.log(extremes.yMax.values[0]);
-        console.log(extremes.yMax.values[1]);
+        expect(extremes.yMax.x).toStrictEqual(x);
+        expect(extremes.yMax.values.length).toBe(2);
+        expect(extremes.yMax.values[0]).toStrictEqual(
+            { name: "a", y: [4, 5, 6], description: "Mean" });
+        expect(extremes.yMax.values[1]).toStrictEqual(
+            { name: "a", y: [4, 4.9, 5.9], description: "Min" });
     });
 });

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -408,6 +408,35 @@ describe("computeExtremes", () => {
         expect(extremes.yMax.values[3]).toStrictEqual(
             { name: "b", y: [12, 10, 12], description: "Min" });
     });
+
+    it("recomputes when run in nonblocking mode", () => {
+        const user = { a: 2 };
+        const pars = batchParsRange(user, "a", 3, false, 0, 4);
+        const control = {};
+        const tStart = 0;
+        const tEnd = 10;
+        const obj = batchRun(User, pars, tStart, tEnd, control, false);
+
+        // Empty case succeeds:
+        const e0 = obj.extreme("yMax");
+        expect(e0.x).toStrictEqual([]);
+        expect(e0.values).toStrictEqual([]);
+
+        // Single case runs
+        obj.compute();
+        const e1 = obj.extreme("yMax");
+        expect(e1.x).toStrictEqual([pars.values[0]]);
+        expect(e1.values[0].y.length).toBe(1);
+
+        // Then do the lot
+        obj.run();
+        const e3 = obj.extreme("yMax");
+        expect(e3.x).toStrictEqual(pars.values);
+        expect(e3.values[0].y.length).toBe(3);
+
+        // Check that the single case was a subset of the full set
+        expect(e3.values[0].y[0]).toBe(e1.values[0].y[0]);
+    });
 });
 
 describe("can prevent issues with misshaped outputs", () => {

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -201,8 +201,8 @@ describe("can extract from a batch result", () => {
 });
 
 // npm run test -- --watch --verbose=false --coverage=false test/batch.test.ts
-describe("new", () => {
-    it("new", () => {
+describe("computeExtremes", () => {
+    it("can work with simple odin output", () => {
         const tStart = 0;
         const tEnd = 10;
         const x = [0, 1, 2]; // parameter values
@@ -213,12 +213,7 @@ describe("new", () => {
             values([1, 2, 3, 4, 5]),
             values([2, 3, 4, 5, 6]),
         ];
-        // console.log(result);
-        // console.log(result[0]);
         const extremes = computeExtremesResult(x, result);
-        // console.log(extremes);
-        // console.log(extremes.tMin);
-        // console.log(extremes.tMin.values[0]);
     });
 
     // This is the trivial dust case; one summary, copy over description
@@ -234,9 +229,6 @@ describe("new", () => {
             values([2, 3, 4, 5, 6]),
         ];
         const extremes = computeExtremesResult(x, result);
-        console.log(extremes);
-        console.log(extremes.yMax);
-        console.log(extremes.yMax.values[0]);
 
         expect(extremes.yMax.x).toStrictEqual(x);
         expect(extremes.yMax.values.length).toBe(1);
@@ -247,7 +239,7 @@ describe("new", () => {
     // This is the usual dust case; we have multiple summary
     // statistics that perfectly align and we want to make sure that
     // we copy over the descriptions.
-    it.only("can work with multiple summaries", () => {
+    it("can work with multiple summaries", () => {
         const tStart = 0;
         const tEnd = 10;
         const x = [0, 1, 2]; // parameter values
@@ -304,5 +296,39 @@ describe("new", () => {
             { name: "a", y: [4, 5, 6], description: "Mean" });
         expect(extremes.yMax.values[1]).toStrictEqual(
             { name: "a", y: [4, 4.9, 5.9], description: "Min" });
+    });
+
+    it("can work with multiple series, too", () => {
+        const tStart = 0;
+        const tEnd = 10;
+        const x = [0, 1, 2]; // parameter values
+        const t = [0, 1, 2, 3, 4];
+        const values = (y: number[]) => ({ x: t, values: [
+            { name: "a", y, description: "Mean" },
+            { name: "a", y: y.map((el) => el - 0.1), description: "Min" },
+            { name: "b", y: y.map((el) => el * 3), description: "Mean" },
+            { name: "b", y: y.map((el) => el * 2), description: "Min" }
+        ]});
+        const result = [
+            {
+                x: t, values: [
+                    { name: "a", y: [0, 1, 2, 3, 4], description: "Deterministic" },
+                    { name: "b", y: [0, 3, 6, 9, 12], description: "Deterministic" }
+                ]
+            },
+            values([1, 2, 3, 4, 5]),
+            values([2, 3, 4, 5, 6]),
+        ];
+        const extremes = computeExtremesResult(x, result);
+        expect(extremes.yMax.x).toStrictEqual(x);
+        expect(extremes.yMax.values.length).toBe(4);
+        expect(extremes.yMax.values[0]).toStrictEqual(
+            { name: "a", y: [4, 5, 6], description: "Mean" });
+        expect(extremes.yMax.values[1]).toStrictEqual(
+            { name: "a", y: [4, 4.9, 5.9], description: "Min" });
+        expect(extremes.yMax.values[2]).toStrictEqual(
+            { name: "b", y: [12, 15, 18], description: "Mean" });
+        expect(extremes.yMax.values[3]).toStrictEqual(
+            { name: "b", y: [12, 10, 12], description: "Min" });
     });
 });

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -200,7 +200,8 @@ describe("can extract from a batch result", () => {
     });
 });
 
-describe.only("new", () => {
+// npm run test -- --watch --verbose=false --coverage=false test/batch.test.ts
+describe("new", () => {
     it("new", () => {
         const tStart = 0;
         const tEnd = 10;
@@ -212,12 +213,12 @@ describe.only("new", () => {
             values([1, 2, 3, 4, 5]),
             values([2, 3, 4, 5, 6]),
         ];
-        console.log(result);
-        console.log(result[0]);
+        // console.log(result);
+        // console.log(result[0]);
         const extremes = computeExtremesResult(x, result);
-        console.log(extremes);
-        console.log(extremes.tMin);
-        console.log(extremes.tMin.values[0]);
+        // console.log(extremes);
+        // console.log(extremes.tMin);
+        // console.log(extremes.tMin.values[0]);
     });
 
     it("can work with elements that have descriptions", () => {
@@ -231,14 +232,15 @@ describe.only("new", () => {
             values([1, 2, 3, 4, 5]),
             values([2, 3, 4, 5, 6]),
         ];
-        console.log(result);
-        console.log(result[0]);
+        // console.log(result);
+        // console.log(result[0]);
         const extremes = computeExtremesResult(x, result);
-        console.log(extremes);
-        console.log(extremes.tMin);
-        console.log(extremes.tMin.values[0]);
+        // console.log(extremes);
+        // console.log(extremes.tMin);
+        // console.log(extremes.tMin.values[0]);
     });
 
+    // This is the error case that we currently have:
     it.only("can work with elements that have descriptions", () => {
         const tStart = 0;
         const tEnd = 10;
@@ -249,15 +251,22 @@ describe.only("new", () => {
             { name: "a", y: y.map((el) => el - 0.1), description: "Min" }
         ]});
         const result = [
-            values([0, 1, 2, 3, 4]),
+            {
+                x: t, values: [{
+                    name: "a",
+                    y: [0, 1, 2, 3, 4],
+                    description: "Deterministic"
+                }]
+            },
             values([1, 2, 3, 4, 5]),
             values([2, 3, 4, 5, 6]),
         ];
-        console.log(result);
-        console.log(result[0]);
+        // console.log(result);
+        // console.log(result[0]);
         const extremes = computeExtremesResult(x, result);
         console.log(extremes);
-        console.log(extremes.tMin);
-        console.log(extremes.tMin.values[0]);
+        console.log(extremes.yMax);
+        console.log(extremes.yMax.values[0]);
+        console.log(extremes.yMax.values[1]);
     });
 });

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -1,4 +1,4 @@
-import { batchParsDisplace, batchParsRange, batchRun, computeExtremesResult, repairDeterministicDescription, updatePars, valueAtTimeResult } from "../src/batch";
+import { batchParsDisplace, batchParsRange, batchRun, computeExtremesResult, alignDescriptionsGetLevels, updatePars, valueAtTimeResult } from "../src/batch";
 import { SeriesSetValues, TimeMode } from "../src/solution";
 import { grid, gridLog } from "../src/util";
 import { wodinRun } from "../src/wodin";
@@ -415,31 +415,31 @@ describe("can prevent issues with misshaped outputs", () => {
 
     it("handles happy cases", () => {
 
-        expect(repairDeterministicDescription([[ssv("a"), ssv("b")]])).toStrictEqual(["a", "b"]);
-        expect(repairDeterministicDescription([[ssv("a"), ssv("b")], [ssv("a"), ssv("b")]])).toStrictEqual(["a", "b"]);
-        expect(repairDeterministicDescription(Array(4).fill([ssv("a"), ssv("b")]))).toStrictEqual(["a", "b"]);
-        expect(repairDeterministicDescription([[ssv("x")], [ssv("a"), ssv("b")]])).toStrictEqual(["a", "b"]);
-        expect(repairDeterministicDescription([[ssv(undefined)], [ssv("a"), ssv("b")]])).toStrictEqual(["a", "b"]);
+        expect(alignDescriptionsGetLevels([[ssv("a"), ssv("b")]])).toStrictEqual(["a", "b"]);
+        expect(alignDescriptionsGetLevels([[ssv("a"), ssv("b")], [ssv("a"), ssv("b")]])).toStrictEqual(["a", "b"]);
+        expect(alignDescriptionsGetLevels(Array(4).fill([ssv("a"), ssv("b")]))).toStrictEqual(["a", "b"]);
+        expect(alignDescriptionsGetLevels([[ssv("x")], [ssv("a"), ssv("b")]])).toStrictEqual(["a", "b"]);
+        expect(alignDescriptionsGetLevels([[ssv(undefined)], [ssv("a"), ssv("b")]])).toStrictEqual(["a", "b"]);
     });
 
     it("prevents mix of undefined and labeled descriptions", () => {
-        expect(() => repairDeterministicDescription([[ssv("a"), ssv(undefined)]]))
+        expect(() => alignDescriptionsGetLevels([[ssv("a"), ssv(undefined)]]))
             .toThrow("Expected all descriptions to be defined");
-        expect(() => repairDeterministicDescription([[ssv("a"), ssv(undefined), ssv("b")]]))
+        expect(() => alignDescriptionsGetLevels([[ssv("a"), ssv(undefined), ssv("b")]]))
             .toThrow("Expected all descriptions to be defined");
     });
 
     it("ensures consistency of unreplicated series", () => {
-        expect(() => repairDeterministicDescription([[ssv("a")], [ssv("b")]]))
+        expect(() => alignDescriptionsGetLevels([[ssv("a")], [ssv("b")]]))
             .toThrow("Unexpected inconsistent descriptions: have a, but given b");
-        expect(() => repairDeterministicDescription([[ssv("a")], [ssv(undefined)]]))
+        expect(() => alignDescriptionsGetLevels([[ssv("a")], [ssv(undefined)]]))
             .toThrow("Unexpected inconsistent descriptions: have a, but given undefined");
     });
 
     it("ensures consistency of replicated series", () => {
-        expect(() => repairDeterministicDescription([[ssv("a"), ssv("b")], [ssv("b"), ssv("a")]]))
+        expect(() => alignDescriptionsGetLevels([[ssv("a"), ssv("b")], [ssv("b"), ssv("a")]]))
             .toThrow("Unexpected inconsistent descriptions: have [a, b], but given [b, a]");
-        expect(() => repairDeterministicDescription([[ssv("a"), ssv("b")], [ssv("a"), ssv("b"), ssv("c")]]))
+        expect(() => alignDescriptionsGetLevels([[ssv("a"), ssv("b")], [ssv("a"), ssv("b"), ssv("c")]]))
             .toThrow("Unexpected inconsistent descriptions: have [a, b], but given [a, b, c]");
     });
 });

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -1,4 +1,4 @@
-import { batchParsDisplace, batchParsRange, batchRun, updatePars } from "../src/batch";
+import { batchParsDisplace, batchParsRange, batchRun, computeExtremesResult, updatePars } from "../src/batch";
 import { TimeMode } from "../src/solution";
 import { grid, gridLog } from "../src/util";
 import { wodinRun } from "../src/wodin";
@@ -197,5 +197,67 @@ describe("can extract from a batch result", () => {
         expect(e.values[1].name).toBe("y");
         expect(approxEqualArray(e.values[0].y, [1, 11, 21, 31, 41])).toBe(true);
         expect(approxEqualArray(e.values[1].y, [2, 22, 42, 62, 82])).toBe(true);
+    });
+});
+
+describe.only("new", () => {
+    it("new", () => {
+        const tStart = 0;
+        const tEnd = 10;
+        const x = [0, 1, 2]; // parameter values
+        const t = [0, 1, 2, 3, 4];
+        const values = (y: number[]) => ({ x: t, values: [{ name: "a", y }] });
+        const result = [
+            values([0, 1, 2, 3, 4]),
+            values([1, 2, 3, 4, 5]),
+            values([2, 3, 4, 5, 6]),
+        ];
+        console.log(result);
+        console.log(result[0]);
+        const extremes = computeExtremesResult(x, result);
+        console.log(extremes);
+        console.log(extremes.tMin);
+        console.log(extremes.tMin.values[0]);
+    });
+
+    it("can work with elements that have descriptions", () => {
+        const tStart = 0;
+        const tEnd = 10;
+        const x = [0, 1, 2]; // parameter values
+        const t = [0, 1, 2, 3, 4];
+        const values = (y: number[]) => ({ x: t, values: [{ name: "a", y, description: "Mean" }] });
+        const result = [
+            values([0, 1, 2, 3, 4]),
+            values([1, 2, 3, 4, 5]),
+            values([2, 3, 4, 5, 6]),
+        ];
+        console.log(result);
+        console.log(result[0]);
+        const extremes = computeExtremesResult(x, result);
+        console.log(extremes);
+        console.log(extremes.tMin);
+        console.log(extremes.tMin.values[0]);
+    });
+
+    it.only("can work with elements that have descriptions", () => {
+        const tStart = 0;
+        const tEnd = 10;
+        const x = [0, 1, 2]; // parameter values
+        const t = [0, 1, 2, 3, 4];
+        const values = (y: number[]) => ({ x: t, values: [
+            { name: "a", y, description: "Mean" },
+            { name: "a", y: y.map((el) => el - 0.1), description: "Min" }
+        ]});
+        const result = [
+            values([0, 1, 2, 3, 4]),
+            values([1, 2, 3, 4, 5]),
+            values([2, 3, 4, 5, 6]),
+        ];
+        console.log(result);
+        console.log(result[0]);
+        const extremes = computeExtremesResult(x, result);
+        console.log(extremes);
+        console.log(extremes.tMin);
+        console.log(extremes.tMin.values[0]);
     });
 });


### PR DESCRIPTION
What a journey.

This PR will allow processing of dust output where we might have multiple summary statistics (https://github.com/mrc-ide/dust-js/pull/14) but also handling the case where sometimes we collapse these summaries when things are deterministic. This was surprisingly horrible to sort out, and I've reworked all the post-processing of solutions based on this.

The three scenarios are:

* the odin one where we have a single series with no description - in this case the behaviour is identical to before
* the dust one where nothing is deterministic and we'll end up with a number of statistics per series, distinguished by their description field. here, we verify that the set of statistics is identical (including order) and copy that out with the summarised output
* there's the special case where we have a parameter value mixed in that collapses the stochastic traces to become deterministic (this could also happen with low replicate counts). Here, we need to repeat that trace for the other summary statistics.

The same approach is required for both "value at time" and for the extremes (ymin, ymax, etc) calculations

Should be reviewed in conjunction with https://github.com/mrc-ide/dust-js/pull/14 - particularly in how we want to model the description field vs a "mode" field