### PR TITLE
mrc-4455 Support multiple varying parameters in batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 dist
 lib

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.1.1",
+    "version": "0.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/odinjs",
-            "version": "0.1.1",
+            "version": "0.1.3",
             "license": "MIT",
             "dependencies": {
                 "@reside-ic/interpolate": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/odinjs",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "odin js/ts support",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -55,7 +55,7 @@ export class Batch {
         this.tEnd = tEnd;
         this.solutions = [];
         this.runStatuses = [];
-        this._pending = Batch.expandVaryingParams(pars.varying);
+        this._pending = this.expandVaryingParams(pars.varying);
         this._run = run;
         this._nPointsForExtremes = nPointsForExtremes;
     }
@@ -65,6 +65,9 @@ export class Batch {
         return this.runStatuses.filter((s) => !s.success);
     }
 
+    /** Returns those varying parameter values which successfully ran. The array returned should correspond by
+     * index to the solutions in the result
+     */
     public get successfulVaryingParams(): UserType[] {
         return this.runStatuses.filter((s) => s.success).map((s) => s.pars);
     }
@@ -134,10 +137,10 @@ export class Batch {
      * represents a single combination of values for the varying parameters. We will combine these with the base
      * pars for each run.
      */
-    private static expandVaryingParams(varyingPars: VaryingPar[]): UserType[] {
+    private expandVaryingParams(varyingPars: VaryingPar[]): UserType[] {
         const result: UserType[] = [];
         const addNextParameterToResult = (nextParameterIdx: number, currentValues: UserType) => {
-            const isLastParam = nextParameterIdx === varyingPars.length-1;
+            const isLastParam = nextParameterIdx === varyingPars.length - 1;
             const par = varyingPars[nextParameterIdx];
             par.values.forEach((value: number) => {
                 const newValues = {...currentValues, [par.name]: value};
@@ -200,7 +203,8 @@ export interface BatchPars {
 
 /**
  * Records success or failure of an individual run, along with the run's combination varying parameter values and any
- * error  */
+ * error
+ */
 export interface RunStatus {
     /** The varying parameter values for this run */
     pars: UserType;

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -60,7 +60,6 @@ export class Batch {
         this.solutions = [];
         this.runStatuses = [];
         this._pending = Batch.expandVaryingParams(pars.varying);
-        //this._pending = [...this._varyingParsValues];
         this._run = run;
         this._nPointsForExtremes = nPointsForExtremes;
     }

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -8,8 +8,6 @@ import { wodinRun } from "./wodin";
 
 export type singleBatchRun = (pars: UserType, tStart: number, tEnd: number) => InterpolatedSolution;
 
-// TODO: throw error if try to run a batch with empty VaryingParams
-
 export class Batch {
     /** The parameters used for this batch run */
     public readonly pars: BatchPars;
@@ -167,7 +165,7 @@ export class Batch {
                 tEnd: this.tEnd,
                 tStart: this.tStart,
             } as const;
-            const extremes = computeExtremes(times as Times, this.successfulVaryingParams, this.solutions);
+            const extremes = computeExtremes(times, this.successfulVaryingParams, this.solutions);
             if (this._pending.length !== 0) {
                 return extremes;
             }
@@ -185,7 +183,7 @@ export class Batch {
 export interface VaryingPar {
     /** The name of the parameter to vary */
     name: string;
-    /** The values that `name` will take, replacing the value in `base` */
+    /** The values that the parameters will take, replacing the value in the base params */
     values: number[];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ export {
 } from "./solution";
 export {
     Batch,
-    BatchError,
     BatchPars,
     Extremes,
     batchParsDisplace,

--- a/src/solution.ts
+++ b/src/solution.ts
@@ -1,5 +1,6 @@
 import { FullSolution } from "./model";
 import { grid } from "./util";
+import {UserType} from "./user";
 
 /**
  * We return a set of series from two different places:
@@ -9,12 +10,22 @@ import { grid } from "./util";
  */
 export interface SeriesSet {
     /** The domain that the series is available at, typically time  */
-    x: number[];
+    x: number[] ;
     /** An array of individual traces, each of which are defined over
      * the same set of `x` values.
      */
     values: SeriesSetValues[];
 }
+
+export interface UserTypeSeriesSet {
+    /** The domain that the series is available at, as a combination of values of the varying parameters  */
+    x: UserType[] ;
+    /** An array of individual traces, each of which are defined over
+     * the same set of `x` values.
+     */
+    values: SeriesSetValues[];
+}
+
 
 export interface SeriesSetValues {
     /**

--- a/src/solution.ts
+++ b/src/solution.ts
@@ -1,6 +1,6 @@
 import { FullSolution } from "./model";
+import { UserType } from "./user";
 import { grid } from "./util";
-import {UserType} from "./user";
 
 /**
  * We return a set of series from two different places:
@@ -10,7 +10,7 @@ import {UserType} from "./user";
  */
 export interface SeriesSet {
     /** The domain that the series is available at, typically time  */
-    x: number[] ;
+    x: number[];
     /** An array of individual traces, each of which are defined over
      * the same set of `x` values.
      */
@@ -25,7 +25,6 @@ export interface UserTypeSeriesSet {
      */
     values: SeriesSetValues[];
 }
-
 
 export interface SeriesSetValues {
     /**

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -3,6 +3,6 @@ export function versions() {
     return {
         dfoptim: "0.0.5",
         dopri: "0.0.13",
-        odinjs: "0.1.1",
+        odinjs: "0.1.2",
     };
 }

--- a/test/models.ts
+++ b/test/models.ts
@@ -408,7 +408,7 @@ export class Oscillate {
 
     rhs(t, state, dstatedt) {
         var internal = this.internal;
-        dstatedt[0] = Math.sin(t * internal.scale);
+        dstatedt[0] = Math.sin(t * internal.scale) + (internal.shift * internal.shiftScale);
     }
 
     initial(t) {
@@ -421,9 +421,13 @@ export class Oscillate {
 
     setUser(user, unusedUserAction) {
         const internal = this.internal;
-        this.base.user.checkUser(user, ["scale"], unusedUserAction);
+        this.base.user.checkUser(user, ["scale", "shift", "shiftScale"], unusedUserAction);
         this.base.user.setUserScalar(user, "scale", internal, 1,
                                      -Infinity, Infinity, false);
+        this.base.user.setUserScalar(user, "shift", internal, 1,
+            -Infinity, Infinity, false);
+        this.base.user.setUserScalar(user, "shiftScale", internal, 1,
+            -Infinity, Infinity, false);
     }
 
     getInternal() {


### PR DESCRIPTION
Adds support for multiple varying parameters in the running of sensitivity. For consistency, running single parameter sensitivity is now done in the same way, with just a single varying parameter defined. 

Key changes:
- in `BatchPars`,  the `name` and `values` props have been replaced by an array of `VaryingPar`s (each of which has a parameter name and array of values). 
- `expandVaryingParams` method is used to generate all combinations of varying params values (as an array of `UserType`s) - `batchRun` iterates through this array and computes for each of these combinations
- `BatchError` has been replaced by `RunStatus` which is recorded for each combination of varying parameter values and includes `success` boolean. the varying parameter values and any error strings.
- Two getters give useful access to the run statuses, the first returning errors only, and the second returning the successful parameter value combinations, which will correspond by index to the returned solutions list
- the summary series sets which previously had the single varying parameter's values as its `x` values, now needs to specify the multiple varying parameter values, so there's now a `UserTypeSeriesSet` type where `x` is an array of UserTypes specifying these multiple values. (Maybe `x` isn't a sensible name for this any more!)